### PR TITLE
MODORDSTOR-12 - Add description fields to mod-orders-storage collection schemas

### DIFF
--- a/mod-orders-storage/schemas/adjustment_collection.json
+++ b/mod-orders-storage/schemas/adjustment_collection.json
@@ -1,8 +1,10 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "collection of adjustment records",
   "type": "object",
   "properties": {
     "adjustments": {
+      "description": "array of adjustment records",
       "type": "array",
       "id": "adjustments",
       "items": {
@@ -11,12 +13,15 @@
       }
     },
     "total_records": {
+      "description": "The number of objects contained in this collection",
       "type": "integer"
     },
     "first": {
+      "description": "The index of the first object contained in this collection",
       "type": "integer"
     },
     "last": {
+      "description": "The index of the last object contained in this collection",
       "type": "integer"
     }
   },

--- a/mod-orders-storage/schemas/alert_collection.json
+++ b/mod-orders-storage/schemas/alert_collection.json
@@ -1,8 +1,10 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "collection of alert records",
   "type": "object",
   "properties": {
     "alerts": {
+      "description": "collection of alert records",
       "type": "array",
       "id": "alerts",
       "items": {
@@ -11,12 +13,15 @@
       }
     },
     "total_records": {
+      "description": "The number of objects contained in this collection",
       "type": "integer"
     },
     "first": {
+      "description": "The index of the first object contained in this collection",
       "type": "integer"
     },
     "last": {
+      "description": "The index of the last object contained in this collection",
       "type": "integer"
     }
   },

--- a/mod-orders-storage/schemas/claim.json
+++ b/mod-orders-storage/schemas/claim.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "details about an order claim",
   "type": "object",
   "properties": {
     "id": {

--- a/mod-orders-storage/schemas/claim_collection.json
+++ b/mod-orders-storage/schemas/claim_collection.json
@@ -1,8 +1,10 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "collection of claim records",
   "type": "object",
   "properties": {
     "claims": {
+      "description": "collection of claim records",
       "type": "array",
       "id": "claims",
       "items": {
@@ -11,12 +13,15 @@
       }
     },
     "total_records": {
+      "description": "The number of objects contained in this collection",
       "type": "integer"
     },
     "first": {
+      "description": "The index of the first object contained in this collection",
       "type": "integer"
     },
     "last": {
+      "description": "The index of the last object contained in this collection",
       "type": "integer"
     }
   },

--- a/mod-orders-storage/schemas/cost_collection.json
+++ b/mod-orders-storage/schemas/cost_collection.json
@@ -1,8 +1,10 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "collection of cost records",
   "type": "object",
   "properties": {
     "costs": {
+      "description": "collection of cost records",
       "type": "array",
       "id": "costs",
       "items": {
@@ -11,12 +13,15 @@
       }
     },
     "total_records": {
+      "description": "The number of objects contained in this collection",
       "type": "integer"
     },
     "first": {
+      "description": "The index of the first object contained in this collection",
       "type": "integer"
     },
     "last": {
+      "description": "The index of the last object contained in this collection",
       "type": "integer"
     }
   },

--- a/mod-orders-storage/schemas/details_collection.json
+++ b/mod-orders-storage/schemas/details_collection.json
@@ -1,8 +1,10 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "collection of detail records",
   "type": "object",
   "properties": {
     "details": {
+      "description": "collection of detail records",
       "type": "array",
       "id": "details",
       "items": {
@@ -11,12 +13,15 @@
       }
     },
     "total_records": {
+      "description": "The number of objects contained in this collection",
       "type": "integer"
     },
     "first": {
+      "description": "The index of the first object contained in this collection",
       "type": "integer"
     },
     "last": {
+      "description": "The index of the last object contained in this collection",
       "type": "integer"
     }
   },

--- a/mod-orders-storage/schemas/eresource_collection.json
+++ b/mod-orders-storage/schemas/eresource_collection.json
@@ -1,8 +1,10 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "collection of eresource records",
   "type": "object",
   "properties": {
     "eresources": {
+      "description": "collection of eresource records",
       "type": "array",
       "id": "eresources",
       "items": {
@@ -11,12 +13,15 @@
       }
     },
     "total_records": {
+      "description": "The number of objects contained in this collection",
       "type": "integer"
     },
     "first": {
+      "description": "The index of the first object contained in this collection",
       "type": "integer"
     },
     "last": {
+      "description": "The index of the last object contained in this collection",
       "type": "integer"
     }
   },

--- a/mod-orders-storage/schemas/license_collection.json
+++ b/mod-orders-storage/schemas/license_collection.json
@@ -1,8 +1,10 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "collection of license records",
   "type": "object",
   "properties": {
     "licenses": {
+      "description": "collection of license records",
       "type": "array",
       "id": "licenses",
       "items": {
@@ -11,12 +13,15 @@
       }
     },
     "total_records": {
+      "description": "The number of objects contained in this collection",
       "type": "integer"
     },
     "first": {
+      "description": "The index of the first object contained in this collection",
       "type": "integer"
     },
     "last": {
+      "description": "The index of the last object contained in this collection",
       "type": "integer"
     }
   },

--- a/mod-orders-storage/schemas/location_collection.json
+++ b/mod-orders-storage/schemas/location_collection.json
@@ -1,8 +1,10 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "collection of location records",
   "type": "object",
   "properties": {
     "locations": {
+      "description": "collection of location records",
       "type": "array",
       "id": "locations",
       "items": {
@@ -11,12 +13,15 @@
       }
     },
     "total_records": {
+      "description": "The number of objects contained in this collection",
       "type": "integer"
     },
     "first": {
+      "description": "The index of the first object contained in this collection",
       "type": "integer"
     },
     "last": {
+      "description": "The index of the last object contained in this collection",
       "type": "integer"
     }
   },

--- a/mod-orders-storage/schemas/physical_collection.json
+++ b/mod-orders-storage/schemas/physical_collection.json
@@ -1,8 +1,10 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "collection of physical records",
   "type": "object",
   "properties": {
     "physicals": {
+      "description": "collection of physical records",
       "type": "array",
       "id": "physicals",
       "items": {
@@ -11,12 +13,15 @@
       }
     },
     "total_records": {
+      "description": "The number of objects contained in this collection",
       "type": "integer"
     },
     "first": {
+      "description": "The index of the first object contained in this collection",
       "type": "integer"
     },
     "last": {
+      "description": "The index of the last object contained in this collection",
       "type": "integer"
     }
   },

--- a/mod-orders-storage/schemas/po_line_collection.json
+++ b/mod-orders-storage/schemas/po_line_collection.json
@@ -1,8 +1,10 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "collection of purchase order line records",
   "type": "object",
   "properties": {
     "po_lines": {
+      "description": "collection of purchase order line records",
       "type": "array",
       "id": "po_lines",
       "items": {
@@ -11,12 +13,15 @@
       }
     },
     "total_records": {
+      "description": "The number of objects contained in this collection",
       "type": "integer"
     },
     "first": {
+      "description": "The index of the first object contained in this collection",
       "type": "integer"
     },
     "last": {
+      "description": "The index of the last object contained in this collection",
       "type": "integer"
     }
   },

--- a/mod-orders-storage/schemas/purchase_order_collection.json
+++ b/mod-orders-storage/schemas/purchase_order_collection.json
@@ -1,8 +1,10 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "collection of purchase order records",
   "type": "object",
   "properties": {
     "purchase_orders": {
+      "description": "collection of purchase order records",
       "type": "array",
       "id": "purchase_orders",
       "items": {
@@ -11,12 +13,15 @@
       }
     },
     "total_records": {
+      "description": "The number of objects contained in this collection",
       "type": "integer"
     },
     "first": {
+      "description": "The index of the first object contained in this collection",
       "type": "integer"
     },
     "last": {
+      "description": "The index of the last object contained in this collection",
       "type": "integer"
     }
   },

--- a/mod-orders-storage/schemas/renewal_collection.json
+++ b/mod-orders-storage/schemas/renewal_collection.json
@@ -1,8 +1,10 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "collection of renewal records",
   "type": "object",
   "properties": {
     "renewals": {
+      "description": "collection of renewal records",
       "type": "array",
       "id": "renewals",
       "items": {
@@ -11,12 +13,15 @@
       }
     },
     "total_records": {
+      "description": "The number of objects contained in this collection",
       "type": "integer"
     },
     "first": {
+      "description": "The index of the first object contained in this collection",
       "type": "integer"
     },
     "last": {
+      "description": "The index of the last object contained in this collection",
       "type": "integer"
     }
   },

--- a/mod-orders-storage/schemas/reporting_code_collection.json
+++ b/mod-orders-storage/schemas/reporting_code_collection.json
@@ -1,8 +1,10 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "collection of reporting code records",
   "type": "object",
   "properties": {
     "reporting_codes": {
+      "description": "collection of reporting code records",
       "type": "array",
       "id": "reporting_codes",
       "items": {
@@ -11,12 +13,15 @@
       }
     },
     "total_records": {
+      "description": "The number of objects contained in this collection",
       "type": "integer"
     },
     "first": {
+      "description": "The index of the first object contained in this collection",
       "type": "integer"
     },
     "last": {
+      "description": "The index of the last object contained in this collection",
       "type": "integer"
     }
   },

--- a/mod-orders-storage/schemas/source_collection.json
+++ b/mod-orders-storage/schemas/source_collection.json
@@ -1,8 +1,10 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "collection of source records",
   "type": "object",
   "properties": {
     "sources": {
+      "description": "collection of source records",
       "type": "array",
       "id": "sources",
       "items": {
@@ -11,12 +13,15 @@
       }
     },
     "total_records": {
+      "description": "The number of objects contained in this collection",
       "type": "integer"
     },
     "first": {
+      "description": "The index of the first object contained in this collection",
       "type": "integer"
     },
     "last": {
+      "description": "The index of the last object contained in this collection",
       "type": "integer"
     }
   },

--- a/mod-orders-storage/schemas/vendor_detail_collection.json
+++ b/mod-orders-storage/schemas/vendor_detail_collection.json
@@ -1,8 +1,10 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "collection of vendor detail records",
   "type": "object",
   "properties": {
     "vendor_details": {
+      "description": "collection of vendor detail records",
       "type": "array",
       "id": "vendor_details",
       "items": {
@@ -11,12 +13,15 @@
       }
     },
     "total_records": {
+      "description": "The number of objects contained in this collection",
       "type": "integer"
     },
     "first": {
+      "description": "The index of the first object contained in this collection",
       "type": "integer"
     },
     "last": {
+      "description": "The index of the last object contained in this collection",
       "type": "integer"
     }
   },


### PR DESCRIPTION
Add description fields to mod-orders-storage *collection schemas, as well as one top-level description that was missed earlier (claim.json).

See [MODORDSTOR-12](https://issues.folio.org/browse/MODORDSTOR-12) for details.

I think this addresses the last of the orders-related raml-cop issues!!!
```
mod-orders$ python3 ../folio-tools/lint-raml/lint_raml_cop.py -l info
INFO: lint-raml-cop: Investigating mod-orders/ramls
INFO: lint-raml-cop: Using submodule ramls/raml-util at 45d45e8cdac093d854673a791a1d73fe0f1e18e9
INFO: lint-raml-cop: Looking for schema files: ./ramls/acq-models/mod-orders-storage/schemas
INFO: lint-raml-cop: Assessing schema files:
INFO: lint-raml-cop: reporting_code_collection.json: Each property "description" is present.
INFO: lint-raml-cop: license_collection.json: Each property "description" is present.
INFO: lint-raml-cop: physical.json: Each property "description" is present.
INFO: lint-raml-cop: source_collection.json: Each property "description" is present.
INFO: lint-raml-cop: purchase_order_collection.json: Each property "description" is present.
INFO: lint-raml-cop: claim_collection.json: Each property "description" is present.
INFO: lint-raml-cop: details.json: Each property "description" is present.
INFO: lint-raml-cop: claim.json: Each property "description" is present.
INFO: lint-raml-cop: po_line_collection.json: Each property "description" is present.
INFO: lint-raml-cop: eresource.json: Each property "description" is present.
INFO: lint-raml-cop: adjustment.json: Each property "description" is present.
INFO: lint-raml-cop: eresource_collection.json: Each property "description" is present.
INFO: lint-raml-cop: location.json: Each property "description" is present.
INFO: lint-raml-cop: source.json: Each property "description" is present.
INFO: lint-raml-cop: details_collection.json: Each property "description" is present.
INFO: lint-raml-cop: alert_collection.json: Each property "description" is present.
INFO: lint-raml-cop: license.json: Each property "description" is present.
INFO: lint-raml-cop: renewal_collection.json: Each property "description" is present.
INFO: lint-raml-cop: cost.json: Each property "description" is present.
INFO: lint-raml-cop: reporting_code.json: Each property "description" is present.
INFO: lint-raml-cop: cost_collection.json: Each property "description" is present.
INFO: lint-raml-cop: location_collection.json: Each property "description" is present.
INFO: lint-raml-cop: purchase_order.json: Each property "description" is present.
INFO: lint-raml-cop: alert.json: Each property "description" is present.
INFO: lint-raml-cop: adjustment_collection.json: Each property "description" is present.
INFO: lint-raml-cop: renewal.json: Each property "description" is present.
INFO: lint-raml-cop: vendor_detail_collection.json: Each property "description" is present.
INFO: lint-raml-cop: po_line.json: Each property "description" is present.
INFO: lint-raml-cop: vendor_detail.json: Each property "description" is present.
INFO: lint-raml-cop: physical_collection.json: Each property "description" is present.
INFO: lint-raml-cop: Assessing RAML files:
INFO: lint-raml-cop: Processing RAML v0.8 file: order.raml
INFO: lint-raml-cop:   raml-cop did not detect any errors with order.raml
INFO: lint-raml-cop: Did not detect any errors.
```