### PR TITLE
Modorders 92 - Added Close Reason of PO schema

### DIFF
--- a/composite_purchase_order.json
+++ b/composite_purchase_order.json
@@ -22,6 +22,11 @@
       "type": "string",
       "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
     },
+    "close_reason": {
+      "description": "Close reason for purchase order",
+      "type": "object",
+      "$ref": "mod-orders-storage/schemas/close_reason.json"
+    },
     "created": {
       "description": "date/time when this purchase order was created",
       "type": "string",

--- a/examples/composite_purchase_order.sample
+++ b/examples/composite_purchase_order.sample
@@ -13,8 +13,8 @@
   "approved": true,
   "assigned_to": "ab18897b-0e40-4f31-896b-9c9adc979a88",
   "close_reason": {
-    "reason" : "CLOSED WITH NO REASON"
-    "note" : "Something went wrong. Reopen it at your own risk"
+    "reason" : "No longer available",
+    "note" : "Items are no longer available to purchase"
   },
   "created": "2010-10-08T03:53:00.000Z",
   "created_by": "ab18897b-0e40-4f31-896b-9c9adc979a88",

--- a/examples/composite_purchase_order.sample
+++ b/examples/composite_purchase_order.sample
@@ -12,6 +12,10 @@
   },
   "approved": true,
   "assigned_to": "ab18897b-0e40-4f31-896b-9c9adc979a88",
+  "close_reason": {
+    "reason" : "CLOSED WITH NO REASON"
+    "note" : "Something went wrong. Reopen it at your own risk"
+  },
   "created": "2010-10-08T03:53:00.000Z",
   "created_by": "ab18897b-0e40-4f31-896b-9c9adc979a88",
   "notes": [

--- a/examples/composite_purchase_orders.sample
+++ b/examples/composite_purchase_orders.sample
@@ -15,8 +15,8 @@
       "approved": true,
       "assigned_to": "ab18897b-0e40-4f31-896b-9c9adc979a88",
       "close_reason": {
-        "reason" : "CLOSED WITH NO REASON"
-        "note" : "Something went wrong. Please, don't reopen it"
+        "reason" : "No longer available",
+        "note" : "Items are no longer available to purchase"
       },
       "created": "2010-10-08T03:53:00.000Z",
       "created_by": "ab18897b-0e40-4f31-896b-9c9adc979a88",

--- a/examples/composite_purchase_orders.sample
+++ b/examples/composite_purchase_orders.sample
@@ -14,6 +14,10 @@
       },
       "approved": true,
       "assigned_to": "ab18897b-0e40-4f31-896b-9c9adc979a88",
+      "close_reason": {
+        "reason" : "CLOSED WITH NO REASON"
+        "note" : "Something went wrong. Please, don't reopen it"
+      },
       "created": "2010-10-08T03:53:00.000Z",
       "created_by": "ab18897b-0e40-4f31-896b-9c9adc979a88",
       "notes": [

--- a/mod-orders-storage/examples/purchase_order_collection.sample
+++ b/mod-orders-storage/examples/purchase_order_collection.sample
@@ -6,8 +6,8 @@
       "approved": true,
       "assigned_to": "ab18897b-0e40-4f31-896b-9c9adc979a88",
       "close_reason": {
-        "reason" : "NO ROOM IN A LIBRARY"
-        "note" : "We suppose, it is enough of 'War and Peace' copies"
+        "reason" : "No longer available",
+        "note" : "Items are no longer available to purchase"
       },
       "created": "2010-10-08T03:53:00.000Z",
       "created_by": "ab18897b-0e40-4f31-896b-9c9adc979a88",

--- a/mod-orders-storage/examples/purchase_order_collection.sample
+++ b/mod-orders-storage/examples/purchase_order_collection.sample
@@ -5,6 +5,10 @@
       "adjustment": "9b3be694-6716-4e14-b81d-8d76f0ae4146",
       "approved": true,
       "assigned_to": "ab18897b-0e40-4f31-896b-9c9adc979a88",
+      "close_reason": {
+        "reason" : "NO ROOM IN A LIBRARY"
+        "note" : "We suppose, it is enough of 'War and Peace' copies"
+      },
       "created": "2010-10-08T03:53:00.000Z",
       "created_by": "ab18897b-0e40-4f31-896b-9c9adc979a88",
       "manual_po": false,

--- a/mod-orders-storage/examples/purchase_order_get.sample
+++ b/mod-orders-storage/examples/purchase_order_get.sample
@@ -3,6 +3,10 @@
   "adjustment": "9b3be694-6716-4e14-b81d-8d76f0ae4146",
   "approved": true,
   "assigned_to": "ab18897b-0e40-4f31-896b-9c9adc979a88",
+  "close_reason": {
+    "reason" : "CLOSED WITH NO REASON"
+    "note" : "Something went wrong. Please, don't reopen it"
+  },
   "created": "2010-10-08T03:53:00.000Z",
   "created_by": "ab18897b-0e40-4f31-896b-9c9adc979a88",
   "manual_po": false,

--- a/mod-orders-storage/examples/purchase_order_get.sample
+++ b/mod-orders-storage/examples/purchase_order_get.sample
@@ -4,8 +4,8 @@
   "approved": true,
   "assigned_to": "ab18897b-0e40-4f31-896b-9c9adc979a88",
   "close_reason": {
-    "reason" : "CLOSED WITH NO REASON"
-    "note" : "Something went wrong. Please, don't reopen it"
+    "reason" : "Shipping delay",
+    "note" : "Two years is too long for shipping of 'Calendar for Year 2017'"
   },
   "created": "2010-10-08T03:53:00.000Z",
   "created_by": "ab18897b-0e40-4f31-896b-9c9adc979a88",

--- a/mod-orders-storage/examples/purchase_order_post.sample
+++ b/mod-orders-storage/examples/purchase_order_post.sample
@@ -2,6 +2,10 @@
   "adjustment": "9b3be694-6716-4e14-b81d-8d76f0ae4146",
   "approved": true,
   "assigned_to": "ab18897b-0e40-4f31-896b-9c9adc979a88",
+  "close_reason": {
+    "reason" : "INSUFFICIENT FUNDS"
+    "note" : "Sorry, somebody spent all our money on Marvel comics"
+  },
   "created": "2010-10-08T03:53:00.000Z",
   "created_by": "ab18897b-0e40-4f31-896b-9c9adc979a88",
   "manual_po": false,

--- a/mod-orders-storage/examples/purchase_order_post.sample
+++ b/mod-orders-storage/examples/purchase_order_post.sample
@@ -3,8 +3,8 @@
   "approved": true,
   "assigned_to": "ab18897b-0e40-4f31-896b-9c9adc979a88",
   "close_reason": {
-    "reason" : "INSUFFICIENT FUNDS"
-    "note" : "Insufficient funds"
+    "reason" : "Insufficient funds",
+    "note" : "We have reached monthly expense limit"
   },
   "created": "2010-10-08T03:53:00.000Z",
   "created_by": "ab18897b-0e40-4f31-896b-9c9adc979a88",

--- a/mod-orders-storage/examples/purchase_order_post.sample
+++ b/mod-orders-storage/examples/purchase_order_post.sample
@@ -4,7 +4,7 @@
   "assigned_to": "ab18897b-0e40-4f31-896b-9c9adc979a88",
   "close_reason": {
     "reason" : "INSUFFICIENT FUNDS"
-    "note" : "Sorry, somebody spent all our money on Marvel comics"
+    "note" : "Insufficient funds"
   },
   "created": "2010-10-08T03:53:00.000Z",
   "created_by": "ab18897b-0e40-4f31-896b-9c9adc979a88",

--- a/mod-orders-storage/schemas/close_reason.json
+++ b/mod-orders-storage/schemas/close_reason.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "purchase order closing reason record",
+  "type": "object",
+  "properties": {
+    "reason ": {
+      "description": "close reason description",
+      "type": "string"
+    },
+    "note": {
+      "description": "free-form notes related to closing reason",
+      "type": "string"
+    }
+  },
+  "additionalProperties": false
+}

--- a/mod-orders-storage/schemas/purchase_order.json
+++ b/mod-orders-storage/schemas/purchase_order.json
@@ -22,6 +22,11 @@
       "type": "string",
       "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
     },
+    "close_reason": {
+      "description": "Close reason for purchase order",
+      "type": "object",
+      "$ref": "close_reason.json"
+    },
     "created": {
       "description": "date/time when this purchase order was created",
       "type": "string",


### PR DESCRIPTION
Defined `close_reason.json` schema. Updated PO and composite PO schemes and samples.
No separate tables were created, so close_reason object completely stores in `purchase_order` table as part of PO.