### PR TITLE
Fixing MODORDSOTR-33: PO Number must be alphaNumeric

### DIFF
--- a/mod-orders-storage/schemas/po_number.json
+++ b/mod-orders-storage/schemas/po_number.json
@@ -6,7 +6,7 @@
     "po_number": {
       "description": "generated purchase order number",
       "type": "string",
-      "pattern": "^[0-9]{5,16}$"
+      "pattern": "^[a-zA-Z0-9]{5,16}$"
     }
   }
 }


### PR DESCRIPTION
*PURPOSE*
Fixing https://issues.folio.org/browse/MODORDSTOR-33

*APPROACH*
PO Number should be a 5-16 AplphaNumeric Characters