### PR TITLE
MODORDERS-108 Define po_number prefix and suffix

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 * Incremental Release Notes here.
 # 2019 Q1
  * [MODORDERS-90](https://issues.folio.org/browse/MODORDERS-90)
+ * [MODORDERS-108](https://issues.folio.org/browse/MODORDERS-108) Define po_number prefix and suffix
  * [MODORDSTOR-31](https://issues.folio.org/browse/MODORDSTOR-31)
 
 # 2018 Q4

--- a/composite_purchase_order.json
+++ b/composite_purchase_order.json
@@ -39,8 +39,8 @@
         "type": "string"
       }
     },
-    "po_number_prefix": {
-      "description": "An optional prefix to this purchase order number. This allows the user to add the desired context to the PO number without needing to edit the sequential number that the system has generated",
+    "poNumberPrefix": {
+      "description": "An optional prefix to this purchase order number. This allows to add the desired context to the PO number without needing to edit the generated sequential number",
       "type": "string",
       "pattern": "^[a-zA-Z0-9]{0,11}$"
     },
@@ -49,8 +49,8 @@
       "type": "string",
       "pattern": "^[a-zA-Z0-9]{5,16}$"
     },
-    "po_number_suffix": {
-      "description": "An optional suffix to this purchase order number. This allows the user to add the desired context to the PO number without needing to edit the sequential number that the system has generated",
+    "poNumberSuffix": {
+      "description": "An optional suffix to this purchase order number. This allows to add the desired context to the PO number without needing to edit the generated sequential number",
       "type": "string",
       "pattern": "^[a-zA-Z0-9]{0,11}$"
     },

--- a/composite_purchase_order.json
+++ b/composite_purchase_order.json
@@ -39,10 +39,20 @@
         "type": "string"
       }
     },
+    "po_number_prefix": {
+      "description": "An optional prefix to this purchase order number. This allows the user to add the desired context to the PO number without needing to edit the sequential number that the system has generated",
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9]{0,11}$"
+    },
     "po_number": {
       "description": "A human readable ID assigned to this purchase order",
       "type": "string",
       "pattern": "^[a-zA-Z0-9]{5,16}$"
+    },
+    "po_number_suffix": {
+      "description": "An optional suffix to this purchase order number. This allows the user to add the desired context to the PO number without needing to edit the sequential number that the system has generated",
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9]{0,11}$"
     },
     "order_type": {
       "description": "the purchase order type",

--- a/examples/composite_purchase_order.sample
+++ b/examples/composite_purchase_order.sample
@@ -22,7 +22,9 @@
     "ABCDEFGHIJKLMNOPQRSTUV"
   ],
   "order_type": "Ongoing",
+  "po_number_prefix": "ABC",
   "po_number": "268758",
+  "po_number_suffix": "XYZ",
   "re_encumber": false,
   "renewal": {
      "cycle": "6 Months",
@@ -162,7 +164,7 @@
         "po_line_id": "8c778aee-97fa-4586-b131-3ea588a728e2"
       },
       "po_line_description": "ABCDEFGHIJKLMNOPQRSTUVWXY",
-      "po_line_number": "268758-03",
+      "po_line_number": "ABC268758XYZ-03",
       "po_line_workflow_status": "Open",
       "publication_date": "2017",
       "publisher": "Schiffer Publishing",

--- a/examples/composite_purchase_order.sample
+++ b/examples/composite_purchase_order.sample
@@ -22,9 +22,9 @@
     "ABCDEFGHIJKLMNOPQRSTUV"
   ],
   "order_type": "Ongoing",
-  "po_number_prefix": "ABC",
+  "poNumberPrefix": "ABC",
   "po_number": "268758",
-  "po_number_suffix": "XYZ",
+  "poNumberSuffix": "XYZ",
   "re_encumber": false,
   "renewal": {
      "cycle": "6 Months",

--- a/examples/composite_purchase_orders.sample
+++ b/examples/composite_purchase_orders.sample
@@ -24,9 +24,9 @@
         "ABCDEFGHIJKLMNOPQRSTUV"
       ],
       "order_type": "Ongoing",
-      "po_number_prefix": "AAA",
+      "poNumberPrefix": "AAA",
       "po_number": "268758",
-      "po_number_suffix": "BBB",
+      "poNumberSuffix": "BBB",
       "re_encumber": false,
       "renewal": {
          "cycle": "6 Months",

--- a/examples/composite_purchase_orders.sample
+++ b/examples/composite_purchase_orders.sample
@@ -24,7 +24,9 @@
         "ABCDEFGHIJKLMNOPQRSTUV"
       ],
       "order_type": "Ongoing",
+      "po_number_prefix": "AAA",
       "po_number": "268758",
+      "po_number_suffix": "BBB",
       "re_encumber": false,
       "renewal": {
          "cycle": "6 Months",

--- a/mod-orders-storage/examples/purchase_order_collection.sample
+++ b/mod-orders-storage/examples/purchase_order_collection.sample
@@ -16,9 +16,9 @@
         "ABCDEFGHIJKLMNOPQRSTUV"
       ],
       "order_type": "Ongoing",
-      "po_number_prefix": "ABC",
+      "poNumberPrefix": "ABC",
       "po_number": "268758",
-      "po_number_suffix": "XYZ",
+      "poNumberSuffix": "XYZ",
       "re_encumber": false,
       "renewal": {
          "cycle": "6 Months",

--- a/mod-orders-storage/examples/purchase_order_collection.sample
+++ b/mod-orders-storage/examples/purchase_order_collection.sample
@@ -16,7 +16,9 @@
         "ABCDEFGHIJKLMNOPQRSTUV"
       ],
       "order_type": "Ongoing",
+      "po_number_prefix": "ABC",
       "po_number": "268758",
+      "po_number_suffix": "XYZ",
       "re_encumber": false,
       "renewal": {
          "cycle": "6 Months",
@@ -28,7 +30,7 @@
       "total_estimated_price": 49.98,
       "total_items": 2,
       "vendor": "168f8a86-d26c-406e-813f-c7527f241ac3",
-      "workflow_status": "Open",
+      "workflow_status": "Pending",
       "metadata": {
         "createdDate": "2018-07-19T00:00:00.000+0000",
         "createdByUserId": "28d1057c-d137-11e8-a8d5-f2801f1b9fd1"

--- a/mod-orders-storage/examples/purchase_order_get.sample
+++ b/mod-orders-storage/examples/purchase_order_get.sample
@@ -14,9 +14,9 @@
     "ABCDEFGHIJKLMNOPQRSTUV"
   ],
   "order_type": "Ongoing",
-  "po_number_prefix": "ABC",
+  "poNumberPrefix": "ABC",
   "po_number": "268758",
-  "po_number_suffix": "XYZ",
+  "poNumberSuffix": "XYZ",
   "re_encumber": false,
   "renewal": {
      "cycle": "6 Months",

--- a/mod-orders-storage/examples/purchase_order_get.sample
+++ b/mod-orders-storage/examples/purchase_order_get.sample
@@ -14,7 +14,9 @@
     "ABCDEFGHIJKLMNOPQRSTUV"
   ],
   "order_type": "Ongoing",
+  "po_number_prefix": "ABC",
   "po_number": "268758",
+  "po_number_suffix": "XYZ",
   "re_encumber": false,
   "renewal": {
      "cycle": "6 Months",
@@ -26,7 +28,7 @@
   "total_estimated_price": 49.98,
   "total_items": 2,
   "vendor": "168f8a86-d26c-406e-813f-c7527f241ac3",
-  "workflow_status": "Open",
+  "workflow_status": "Closed",
   "metadata": {
     "createdDate": "2018-07-19T00:00:00.000+0000",
     "createdByUserId": "28d1057c-d137-11e8-a8d5-f2801f1b9fd1"

--- a/mod-orders-storage/examples/purchase_order_post.sample
+++ b/mod-orders-storage/examples/purchase_order_post.sample
@@ -9,9 +9,9 @@
     "ABCDEFGHIJKLMNOPQRSTUV"
   ],
   "order_type": "Ongoing",
-  "po_number_prefix": "FEB",
+  "poNumberPrefix": "FEB",
   "po_number": "268758",
-  "po_number_suffix": "2019",
+  "poNumberSuffix": "2019",
   "re_encumber": false,
   "renewal": {
      "cycle": "6 Months",

--- a/mod-orders-storage/examples/purchase_order_post.sample
+++ b/mod-orders-storage/examples/purchase_order_post.sample
@@ -2,10 +2,6 @@
   "adjustment": "9b3be694-6716-4e14-b81d-8d76f0ae4146",
   "approved": true,
   "assigned_to": "ab18897b-0e40-4f31-896b-9c9adc979a88",
-  "close_reason": {
-    "reason" : "Insufficient funds",
-    "note" : "We have reached monthly expense limit"
-  },
   "manual_po": false,
   "notes": [
     "ABCDEFGHIJKLMNO",
@@ -13,7 +9,9 @@
     "ABCDEFGHIJKLMNOPQRSTUV"
   ],
   "order_type": "Ongoing",
+  "po_number_prefix": "FEB",
   "po_number": "268758",
+  "po_number_suffix": "2019",
   "re_encumber": false,
   "renewal": {
      "cycle": "6 Months",
@@ -25,5 +23,5 @@
   "total_estimated_price": 49.98,
   "total_items": 2,
   "vendor": "168f8a86-d26c-406e-813f-c7527f241ac3",
-  "workflow_status": "Open"
+  "workflow_status": "Pending"
 }

--- a/mod-orders-storage/schemas/po_number.json
+++ b/mod-orders-storage/schemas/po_number.json
@@ -3,10 +3,24 @@
   "description": "Generated PO number object",
   "type": "object",
   "properties": {
+    "po_number_prefix": {
+      "description": "An optional prefix to this purchase order number. This allows the user to add the desired context to the PO number without needing to edit the sequential number that the system has generated",
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9]{0,11}$"
+    },
     "po_number": {
-      "description": "generated purchase order number",
+      "description": "A human readable generated or manually entered ID assigned to the purchase order",
       "type": "string",
       "pattern": "^[a-zA-Z0-9]{5,16}$"
+    },
+    "po_number_suffix": {
+      "description": "An optional suffix to this purchase order number. This allows the user to add the desired context to the PO number without needing to edit the sequential number that the system has generated",
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9]{0,11}$"
     }
-  }
+  },
+  "required": [
+    "po_number"
+  ],
+  "additionalProperties": false
 }

--- a/mod-orders-storage/schemas/po_number.json
+++ b/mod-orders-storage/schemas/po_number.json
@@ -3,8 +3,8 @@
   "description": "Generated PO number object",
   "type": "object",
   "properties": {
-    "po_number_prefix": {
-      "description": "An optional prefix to this purchase order number. This allows the user to add the desired context to the PO number without needing to edit the sequential number that the system has generated",
+    "poNumberPrefix": {
+      "description": "An optional prefix to the purchase order number. This allows to add the desired context to the PO number without needing to edit the generated sequential number",
       "type": "string",
       "pattern": "^[a-zA-Z0-9]{0,11}$"
     },
@@ -13,8 +13,8 @@
       "type": "string",
       "pattern": "^[a-zA-Z0-9]{5,16}$"
     },
-    "po_number_suffix": {
-      "description": "An optional suffix to this purchase order number. This allows the user to add the desired context to the PO number without needing to edit the sequential number that the system has generated",
+    "poNumberSuffix": {
+      "description": "An optional suffix to the purchase order number. This allows to add the desired context to the PO number without needing to edit the generated sequential number",
       "type": "string",
       "pattern": "^[a-zA-Z0-9]{0,11}$"
     }

--- a/mod-orders-storage/schemas/purchase_order.json
+++ b/mod-orders-storage/schemas/purchase_order.json
@@ -39,8 +39,8 @@
         "type": "string"
       }
     },
-    "po_number_prefix": {
-      "description": "An optional prefix to this purchase order number. This allows the user to add the desired context to the PO number without needing to edit the sequential number that the system has generated",
+    "poNumberPrefix": {
+      "description": "An optional prefix to this purchase order number. This allows to add the desired context to the PO number without needing to edit the generated sequential number",
       "type": "string",
       "pattern": "^[a-zA-Z0-9]{0,11}$"
     },
@@ -49,8 +49,8 @@
       "type": "string",
       "pattern": "^[a-zA-Z0-9]{5,16}$"
     },
-    "po_number_suffix": {
-      "description": "An optional suffix to this purchase order number. This allows the user to add the desired context to the PO number without needing to edit the sequential number that the system has generated",
+    "poNumberSuffix": {
+      "description": "An optional suffix to this purchase order number. This allows to add the desired context to the PO number without needing to edit the generated sequential number",
       "type": "string",
       "pattern": "^[a-zA-Z0-9]{0,11}$"
     },

--- a/mod-orders-storage/schemas/purchase_order.json
+++ b/mod-orders-storage/schemas/purchase_order.json
@@ -39,10 +39,20 @@
         "type": "string"
       }
     },
+    "po_number_prefix": {
+      "description": "An optional prefix to this purchase order number. This allows the user to add the desired context to the PO number without needing to edit the sequential number that the system has generated",
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9]{0,11}$"
+    },
     "po_number": {
       "description": "A human readable ID assigned to this purchase order",
       "type": "string",
       "pattern": "^[a-zA-Z0-9]{5,16}$"
+    },
+    "po_number_suffix": {
+      "description": "An optional suffix to this purchase order number. This allows the user to add the desired context to the PO number without needing to edit the sequential number that the system has generated",
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9]{0,11}$"
     },
     "order_type": {
       "description": "the purchase order type",


### PR DESCRIPTION
## Purpose
User must have the ability to add prefix or suffix to PO number when creating a purchase order. This allows the user to add the desired context to the PO number without needing to edit the sequential number that the system has generated. Please refer to [MODORDERS-96](https://issues.folio.org/browse/MODORDERS-96) for more details.

## Approach
- Adding `poNumberPrefix` and `poNumberSuffix` to the purchase_order/po_number/composite_purchase_order schemas.
- The po_number.json schema updated as well so it can be used for validation of the combination prefix + po_number + suffix (please see [MODORDERS-89](https://issues.folio.org/browse/MODORDERS-89)) because only business logic module should be aware about the approach of how to concatenate these data
- Updating examples
