### PR TITLE
MODORDSTOR-40 Unable to save Line with order_format Other

### DIFF
--- a/composite_po_line.json
+++ b/composite_po_line.json
@@ -139,11 +139,10 @@
       "description": "The purchase order line format",
       "type": "string",
       "enum": [
-        "Container",
         "Electronic Resource",
         "P/E Mix",
         "Physical Resource",
-        "Service"
+        "Other"
       ]
     },
     "owner": {

--- a/mod-orders-storage/schemas/po_line.json
+++ b/mod-orders-storage/schemas/po_line.json
@@ -139,11 +139,10 @@
       "description": "The purchase order line format",
       "type": "string",
       "enum": [
-        "Container",
         "Electronic Resource",
         "P/E Mix",
         "Physical Resource",
-        "Service"
+        "Other"
       ]
     },
     "owner": {


### PR DESCRIPTION
## Purpose
According to the latest requirements, the list of allowed values for "order_format" field should be as follows:
- Electronic Resource
- Physical Resource
- P/E Mix
- Other

## Approach
- composite_po_line.json and po_line.json schemas were updated
- the samples are not updated as they are already in agreement with the latest list

## Notes
- once this PR is merged, mod-orders and mod-orders-storage modules must be updated to point the latest version of acq-models sub-module