### PR TITLE
MODORDERS-128 PUT orders - handle empty array of the PO lines

### DIFF
--- a/composite_purchase_order.json
+++ b/composite_purchase_order.json
@@ -90,7 +90,8 @@
       "items": {
         "type": "object",
         "$ref": "composite_po_line.json"
-      }
+      },
+      "default": null
     },
     "metadata": {
       "type": "object",


### PR DESCRIPTION
## Purpose
[MODORDERS-128](https://issues.folio.org/browse/MODORDERS-128)  In case a request that contains an empty po_lines array, all the PO Lines should be removed

## Approach
- changed default value of po_lines from empty list to null, so that we can distinguish when the request does not include po_lines and when it contains empty array of poLines.