### PR TITLE
Removing PO_line_workflow_status

### DIFF
--- a/composite_po_line.json
+++ b/composite_po_line.json
@@ -175,15 +175,6 @@
       "type": "string",
       "pattern": "^[a-zA-Z0-9]{5,16}-[0-9]{1,3}$"
     },
-    "po_line_workflow_status": {
-      "description": "The status of this purchase order line",
-      "type": "string",
-      "enum": [
-        "Closed",
-        "Open",
-        "Pending"
-      ]
-    },
     "publication_date": {
       "description": "date (year) of the material's publication",
       "type": "string",

--- a/examples/composite_po_line.sample
+++ b/examples/composite_po_line.sample
@@ -121,7 +121,6 @@
   },
   "po_line_description": "ABCDEFGHIJKLMNOPQRSTUVWXY",
   "po_line_number": "268758-03",
-  "po_line_workflow_status": "Open",
   "publication_date": "2017",
   "publisher": "Schiffer Publishing",
   "purchase_order_id": "d79b0bcc-DcAD-1E4E-Abb7-DbFcaD5BB3bb",

--- a/examples/composite_purchase_order.sample
+++ b/examples/composite_purchase_order.sample
@@ -163,7 +163,6 @@
       },
       "po_line_description": "ABCDEFGHIJKLMNOPQRSTUVWXY",
       "po_line_number": "ABC268758XYZ-03",
-      "po_line_workflow_status": "Open",
       "publication_date": "2017",
       "publisher": "Schiffer Publishing",
       "purchase_order_id": "d79b0bcc-DcAD-1E4E-Abb7-DbFcaD5BB3bb",

--- a/mod-orders-storage/examples/po_line_collection.sample
+++ b/mod-orders-storage/examples/po_line_collection.sample
@@ -38,7 +38,6 @@
         "physical": "5ee243f9-72e5-4464-bdbc-43a21873d648",
         "po_line_description": "ABCDEFGHIJKLMNOPQRSTUVWXY",
         "po_line_number": "268758-03",
-        "po_line_workflow_status": "Open",
         "publication_date": "2017",
         "publisher": "Schiffer Publishing",
         "purchase_order_id": "d79b0bcc-DcAD-1E4E-Abb7-DbFcaD5BB3bb",

--- a/mod-orders-storage/examples/po_line_get.sample
+++ b/mod-orders-storage/examples/po_line_get.sample
@@ -36,7 +36,6 @@
   "physical": "5ee243f9-72e5-4464-bdbc-43a21873d648",
   "po_line_description": "ABCDEFGHIJKLMNOPQRSTUVWXY",
   "po_line_number": "268758-03",
-  "po_line_workflow_status": "Open",
   "publication_date": "2017",
   "publisher": "Schiffer Publishing",
   "purchase_order_id": "d79b0bcc-DcAD-1E4E-Abb7-DbFcaD5BB3bb",

--- a/mod-orders-storage/examples/po_line_post.sample
+++ b/mod-orders-storage/examples/po_line_post.sample
@@ -35,7 +35,6 @@
   "physical": "5ee243f9-72e5-4464-bdbc-43a21873d648",
   "po_line_description": "ABCDEFGHIJKLMNOPQRSTUVWXY",
   "po_line_number": "268758-03",
-  "po_line_workflow_status": "Open",
   "publication_date": "2017",
   "publisher": "Schiffer Publishing",
   "purchase_order_id": "d79b0bcc-DcAD-1E4E-Abb7-DbFcaD5BB3bb",

--- a/mod-orders-storage/schemas/po_line.json
+++ b/mod-orders-storage/schemas/po_line.json
@@ -175,15 +175,6 @@
       "type": "string",
       "pattern": "^[a-zA-Z0-9]{5,16}-[0-9]{1,3}$"
     },
-    "po_line_workflow_status": {
-      "description": "The status of this purchase order line",
-      "type": "string",
-      "enum": [
-        "Closed",
-        "Open",
-        "Pending"
-      ]
-    },
     "publication_date": {
       "description": "date (year) of the material's publication",
       "type": "string",


### PR DESCRIPTION
https://issues.folio.org/browse/MODORDERS-129

## Purpose
PO Line should always share the status of corresponding Purchase Order. As a result remove the workflow status status field from all po line references

## Approach
Remove po_line_workflow_status field