### PR TITLE
MODORDERS-128 PUT orders - handle empty array of the PO lines

### DIFF
--- a/composite_purchase_order.json
+++ b/composite_purchase_order.json
@@ -90,8 +90,7 @@
       "items": {
         "type": "object",
         "$ref": "composite_po_line.json"
-      },
-      "default": null
+      }
     },
     "metadata": {
       "type": "object",


### PR DESCRIPTION
- composite_purchase_order.json removed "default: null" for po_lines