### PR TITLE
MODORDERS-145 Unable to create new Purchase Order with PO Line

### DIFF
--- a/composite_po_line.json
+++ b/composite_po_line.json
@@ -258,5 +258,8 @@
       "readonly": true
     }
   },
-  "additionalProperties": false
+  "additionalProperties": false,
+  "required": [
+    "source"
+  ]
 }

--- a/composite_purchase_order.json
+++ b/composite_purchase_order.json
@@ -81,7 +81,8 @@
         "Pending",
         "Open",
         "Closed"
-      ]
+      ],
+      "default": "Pending"
     },
     "po_lines": {
       "description": "a list of completely de-referenced purchase order lines",

--- a/mod-orders-storage/schemas/po_line.json
+++ b/mod-orders-storage/schemas/po_line.json
@@ -259,5 +259,8 @@
       "readonly": true
     }
   },
-  "additionalProperties": false
+  "additionalProperties": false,
+  "required": [
+    "source"
+  ]
 }


### PR DESCRIPTION
make "source" a required element
set default value for workflow_status

## Purpose
* PO line "source" element must be required according to the documentation
* PO "workflow_status" must be required according to the documentation
https://docs.google.com/spreadsheets/d/1F88PoSnEKD7oFnza1ZuOgzAgKnK95XOyTQzxyww3tZA/edit#gid=1408113181&range=A92

## Approach
* Update po_line.json (storage schema) and composite_po_line.json (mod-orders schema) to make "source" element required, so that it is enforced by the validation logic
* Update composite_purchase_order.json schema to specify default value of "Pending" for workflow_status
This is alternative (and likely better) option to simply making it mandatory and requiring clients to always provide one.