### PR TITLE
MODORDERS-147 Update Purchase Order schema: Add dateOrdered field

### DIFF
--- a/composite_purchase_order.json
+++ b/composite_purchase_order.json
@@ -27,6 +27,12 @@
       "type": "object",
       "$ref": "mod-orders-storage/schemas/close_reason.json"
     },
+    "dateOrdered": {
+      "description": "Date and time when purchase order was opened",
+      "type": "string",
+      "format": "date-time",
+      "readonly": true
+    },
     "manual_po": {
       "description": "if true, order cannot be sent automatically, e.g. via EDI",
       "type": "boolean"

--- a/examples/composite_purchase_order.sample
+++ b/examples/composite_purchase_order.sample
@@ -16,6 +16,7 @@
     "reason" : "No longer available",
     "note" : "Items are no longer available to purchase"
   },
+  "dateOrdered": "2018-07-20T00:00:00.000+0000",
   "notes": [
     "ABCDEFGHIJKLMNO",
     "ABCDEFGHIJKLMNOPQRST",

--- a/examples/composite_purchase_orders.sample
+++ b/examples/composite_purchase_orders.sample
@@ -18,6 +18,7 @@
         "reason" : "No longer available",
         "note" : "Items are no longer available to purchase"
       },
+      "dateOrdered": "2018-07-20T00:00:00.000+0000",
       "notes": [
         "ABCDEFGHIJKLMNO",
         "ABCDEFGHIJKLMNOPQRST",

--- a/mod-orders-storage/examples/purchase_order_get.sample
+++ b/mod-orders-storage/examples/purchase_order_get.sample
@@ -7,6 +7,7 @@
     "reason" : "Shipping delay",
     "note" : "Two years is too long for shipping of 'Calendar for Year 2017'"
   },
+  "dateOrdered": "2018-08-20T00:00:00.000+0000",
   "manual_po": false,
   "notes": [
     "ABCDEFGHIJKLMNO",
@@ -28,7 +29,7 @@
   "vendor": "168f8a86-d26c-406e-813f-c7527f241ac3",
   "workflow_status": "Closed",
   "metadata": {
-    "createdDate": "2018-07-19T00:00:00.000+0000",
+    "createdDate": "2018-08-19T00:00:00.000+0000",
     "createdByUserId": "28d1057c-d137-11e8-a8d5-f2801f1b9fd1"
   }
 }

--- a/mod-orders-storage/schemas/purchase_order.json
+++ b/mod-orders-storage/schemas/purchase_order.json
@@ -27,6 +27,11 @@
       "type": "object",
       "$ref": "close_reason.json"
     },
+    "dateOrdered": {
+      "description": "Date and time when purchase order was opened",
+      "type": "string",
+      "format": "date-time"
+    },
     "manual_po": {
       "description": "if true, order cannot be sent automatically, e.g. via EDI",
       "type": "boolean"


### PR DESCRIPTION
## Purpose
[MODORDERS-147](https://issues.folio.org/browse/MODORDERS-147) Update Purchase Order schema: Add dateOrdered field

## Approach
- added dateOrdered to purchase_order and composite_purchase_order schemas
- set "readOnly": true for "dateOrdered" field in composite_purchase_order schema
- samples updated
