### PR TITLE
MODVEND-75 Added expected_receipt_interval property to mod-vendor.vendor.json model

### DIFF
--- a/mod-vendors/examples/vendor_get.sample
+++ b/mod-vendors/examples/vendor_get.sample
@@ -159,6 +159,7 @@
   "expected_invoice_interval": 5,
   "renewal_activation_interval": 1,
   "subscription_interval": 365,
+  "expected_receipt_interval": 1,
   "liable_for_vat": false,
   "tax_id": "TX-GOBI-HIST",
   "tax_percentage": 5,

--- a/mod-vendors/examples/vendor_post.sample
+++ b/mod-vendors/examples/vendor_post.sample
@@ -159,6 +159,7 @@
   "expected_invoice_interval": 5,
   "renewal_activation_interval": 1,
   "subscription_interval": 365,
+  "expected_receipt_interval": 1,
   "liable_for_vat": false,
   "tax_id": "TX-GOBI-HIST",
   "tax_percentage": 5,

--- a/mod-vendors/examples/vendor_put.sample
+++ b/mod-vendors/examples/vendor_put.sample
@@ -159,6 +159,7 @@
   "expected_invoice_interval": 5,
   "renewal_activation_interval": 1,
   "subscription_interval": 365,
+  "expected_receipt_interval": 1,
   "liable_for_vat": false,
   "tax_id": "TX-GOBI-HIST",
   "tax_percentage": 5,

--- a/mod-vendors/schemas/vendor.json
+++ b/mod-vendors/schemas/vendor.json
@@ -133,23 +133,23 @@
       "type": "number"
     },
     "expected_activation_interval": {
-      "description": "The expected activation interval for this vendor",
+      "description": "The expected activation interval (in days) for this vendor",
       "type": "integer"
     },
     "expected_invoice_interval": {
-      "description": "The expected invoice interval for this vendor",
+      "description": "The expected invoice interval (in days) for this vendor",
       "type": "integer"
     },
     "renewal_activation_interval": {
-      "description": "The revewal activation interval for this vendor",
+      "description": "The revewal activation interval (in days) for this vendor",
       "type": "integer"
     },
     "subscription_interval": {
-      "description": "The subscription interval for this vendor",
+      "description": "The subscription interval (in days) for this vendor",
       "type": "integer"
     },
     "expected_receipt_interval": {
-      "description": "The receipt interval for this vendor",
+      "description": "The receipt interval (in days) for this vendor",
       "type": "integer"
     },
     "tax_id": {

--- a/mod-vendors/schemas/vendor.json
+++ b/mod-vendors/schemas/vendor.json
@@ -148,6 +148,10 @@
       "description": "The subscription interval for this vendor",
       "type": "integer"
     },
+    "expected_receipt_interval": {
+      "description": "The receipt interval for this vendor",
+      "type": "integer"
+    },
     "tax_id": {
       "description": "The tax ID for this vendor",
       "type": "string"


### PR DESCRIPTION
## Purpose
The vendor creation form requires a way to specify the expected receipt interval for a given vendor.  Behaviour conforms to the restrictions of an integer.

 https://issues.folio.org/browse/MODVEND-75


## Approach
The property was added to the vendor model as an integer.

