### PR TITLE
MODORDERS-150 Saving Order with modified po_number field fails

### DIFF
--- a/mod-orders-storage/schemas/purchase_order.json
+++ b/mod-orders-storage/schemas/purchase_order.json
@@ -86,7 +86,8 @@
         "Pending",
         "Open",
         "Closed"
-      ]
+      ],
+      "default": "Pending"
     },
     "metadata": {
       "type": "object",


### PR DESCRIPTION
## Purpose
[MODORDERS-150](https://issues.folio.org/browse/MODORDERS-150) Define default workflow status

## Approach
Defining `Pending` status as default value for workflow status in the purchase order schema