### PR TITLE
MODORDERS-154 make location repeatable

### DIFF
--- a/composite_po_line.json
+++ b/composite_po_line.json
@@ -130,10 +130,15 @@
         "$ref": "mod-orders-storage/schemas/fund_distribution.json"
       }
     },
-    "location": {
-      "description": "location details of this purchase order line",
-      "type": "object",
-      "$ref": "mod-orders-storage/schemas/location.json"
+    "locations": {
+      "description": "a list of the location records for this purchase order line",
+      "id": "locations",
+      "type": "array",
+      "items": {
+        "description": "The location details",
+        "type": "object",
+        "$ref": "mod-orders-storage/schemas/location.json"
+      }
     },
     "order_format": {
       "description": "The purchase order line format",

--- a/examples/composite_po_line.sample
+++ b/examples/composite_po_line.sample
@@ -47,9 +47,9 @@
     "list_price": 24.99,
     "id": "e047212b-c94f-4cb1-84b0-367848381494",
     "currency": "USD",
-    "quantity_physical": 1,
+    "quantity_physical": 6,
     "quantity_electronic": 1,
-    "po_line_estimated_price": 49.98,
+    "po_line_estimated_price": 174.93,
     "po_line_id": "8c778aee-97fa-4586-b131-3ea588a728e2"
   },
   "description": "ABCDEFGH",
@@ -99,15 +99,25 @@
       "po_line_id": "c0d08448-347b-418a-8c2f-5fb50248d67e"
     }
   ],
-  "location": {
-    "id": "a4e65e03-99a4-4b39-8e6a-ae666ac52bea",
-    "location_id": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
-    "quantity": 2,
-    "quantity_electronic": 1,
-    "quantity_physical": 1,
-    "po_line_id": "8c778aee-97fa-4586-b131-3ea588a728e2"
-  },
-  "order_format": "Physical Resource",
+  "locations": [
+    {
+      "id": "a4e65e03-99a4-4b39-8e6a-ae666ac52bea",
+      "location_id": "b241764c-1466-4e1d-a028-1a3684a5da87",
+      "quantity": 5,
+      "quantity_electronic": 1,
+      "quantity_physical": 4,
+      "po_line_id": "8c778aee-97fa-4586-b131-3ea588a728e2"
+    },
+    {
+      "id": "7d23e4e3-5043-44b0-9507-66e58d236f20",
+      "location_id": "fcd64ce1-6995-48f0-840e-89ffa2288371",
+      "quantity": 2,
+      "quantity_electronic": 0,
+      "quantity_physical": 2,
+      "po_line_id": "8c778aee-97fa-4586-b131-3ea588a728e2"
+    }
+  ],
+  "order_format": "P/E Mix",
   "owner": "ABCDEFGHIJKLMNOPQRSTUVWXYZABC",
   "payment_status": "Awaiting Payment",
   "physical": {

--- a/examples/composite_purchase_order.sample
+++ b/examples/composite_purchase_order.sample
@@ -32,8 +32,8 @@
      "review_period": 30,
      "renewal_date": "2019-04-09T00:00:00.000Z"
   },
-  "total_estimated_price": 49.98,
-  "total_items": 2,
+  "total_estimated_price": 74.97,
+  "total_items": 3,
   "vendor": "168f8a86-d26c-406e-813f-c7527f241ac3",
   "workflow_status": "Open",
   "metadata": {
@@ -42,7 +42,7 @@
   },
   "compositePoLines": [
     {
-      "id": "c0d08448-347b-418a-8c2f-5fb50248d67e",
+      "id": "8c778aee-97fa-4586-b131-3ea588a728e2",
       "edition": "First edition",
       "checkin_items": false,
       "instance_id": "8343e5a0-fed8-11e8-8eb2-f2801f1b9fd1",
@@ -90,9 +90,9 @@
         "list_price": 24.99,
         "id": "e047212b-c94f-4cb1-84b0-367848381494",
         "currency": "USD",
-        "quantity_physical": 1,
-        "quantity_electronic": 1,
-        "po_line_estimated_price": 49.98,
+        "quantity_physical": 3,
+        "quantity_electronic": 0,
+        "po_line_estimated_price": 74.97,
         "po_line_id": "8c778aee-97fa-4586-b131-3ea588a728e2"
       },
       "description": "ABCDEFGH",
@@ -118,7 +118,7 @@
         "id": "468b679c-378b-4009-9a17-a6711cefc85f",
         "activated": false,
         "activation_due": 10,
-        "create_inventory": true,
+        "create_inventory": false,
         "trial": false,
         "expected_activation": "2018-10-09T00:00:00.000Z",
         "user_limit": 10,
@@ -132,24 +132,34 @@
           "code": "HIST",
           "percentage": 80.0,
           "encumbrance": "eb506834-6c70-4239-8d1a-6414a5b08ac3",
-          "po_line_id": "c0d08448-347b-418a-8c2f-5fb50248d67e"
+          "po_line_id": "8c778aee-97fa-4586-b131-3ea588a728e2"
         },
         {
           "id": "0d1b2d39-512f-4e0f-a497-b89eba6ecae9",
           "code": "GENRL",
           "percentage": 20.0,
           "encumbrance": "0466cb77-0344-43c6-85eb-0a64aa2934e5",
-          "po_line_id": "c0d08448-347b-418a-8c2f-5fb50248d67e"
+          "po_line_id": "8c778aee-97fa-4586-b131-3ea588a728e2"
         }
       ],
-      "location": {
-        "id": "a4e65e03-99a4-4b39-8e6a-ae666ac52bea",
-        "location_id": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
-        "quantity": 2,
-        "quantity_electronic": 1,
-        "quantity_physical": 1,
-        "po_line_id": "8c778aee-97fa-4586-b131-3ea588a728e2"
-      },
+      "locations": [
+        {
+          "id": "a4e65e03-99a4-4b39-8e6a-ae666ac52bea",
+          "location_id": "b241764c-1466-4e1d-a028-1a3684a5da87",
+          "quantity": 2,
+          "quantity_electronic": 0,
+          "quantity_physical": 2,
+          "po_line_id": "8c778aee-97fa-4586-b131-3ea588a728e2"
+        },
+        {
+          "id": "7d23e4e3-5043-44b0-9507-66e58d236f20",
+          "location_id": "fcd64ce1-6995-48f0-840e-89ffa2288371",
+          "quantity": 1,
+          "quantity_electronic": 0,
+          "quantity_physical": 1,
+          "po_line_id": "8c778aee-97fa-4586-b131-3ea588a728e2"
+        }
+      ],
       "order_format": "Physical Resource",
       "owner": "ABCDEFGHIJKLMNOPQRSTUVWXYZABC",
       "payment_status": "Awaiting Payment",

--- a/mod-orders-storage/examples/po_line_collection.sample
+++ b/mod-orders-storage/examples/po_line_collection.sample
@@ -31,7 +31,10 @@
         "fund_distribution": [
           "d10879e8-8c2d-4850-bcb9-0ec8e2e10021"
         ],
-        "location": "a4e65e03-99a4-4b39-8e6a-ae666ac52bea",
+        "locations": [
+          "a4e65e03-99a4-4b39-8e6a-ae666ac52bea",
+          "7d23e4e3-5043-44b0-9507-66e58d236f20"
+        ],
         "order_format": "Physical Resource",
         "owner": "ABCDEFGHIJKLMNOPQRSTUVWXYZABC",
         "payment_status": "Awaiting Payment",

--- a/mod-orders-storage/examples/po_line_get.sample
+++ b/mod-orders-storage/examples/po_line_get.sample
@@ -29,7 +29,10 @@
   "fund_distribution": [
     "d10879e8-8c2d-4850-bcb9-0ec8e2e10021"
   ],
-  "location": "a4e65e03-99a4-4b39-8e6a-ae666ac52bea",
+  "locations": [
+    "a4e65e03-99a4-4b39-8e6a-ae666ac52bea",
+    "7d23e4e3-5043-44b0-9507-66e58d236f20"
+  ],
   "order_format": "Physical Resource",
   "owner": "ABCDEFGHIJKLMNOPQRSTUVWXYZABC",
   "payment_status": "Awaiting Payment",

--- a/mod-orders-storage/examples/po_line_post.sample
+++ b/mod-orders-storage/examples/po_line_post.sample
@@ -28,7 +28,10 @@
   "fund_distribution": [
     "d10879e8-8c2d-4850-bcb9-0ec8e2e10021"
   ],
-  "location": "a4e65e03-99a4-4b39-8e6a-ae666ac52bea",
+  "locations": [
+    "a4e65e03-99a4-4b39-8e6a-ae666ac52bea",
+    "7d23e4e3-5043-44b0-9507-66e58d236f20"
+  ],
   "order_format": "Physical Resource",
   "owner": "ABCDEFGHIJKLMNOPQRSTUVWXYZABC",
   "payment_status": "Awaiting Payment",

--- a/mod-orders-storage/schemas/po_line.json
+++ b/mod-orders-storage/schemas/po_line.json
@@ -130,10 +130,15 @@
         "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
       }
     },
-    "location": {
-      "description": "UUID of the location record",
-      "type": "string",
-      "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+    "locations": {
+      "description": "the UUIDs of the location records for this purchase order line",
+      "id": "locations",
+      "type": "array",
+      "items": {
+        "description": "UUID of the location record",
+        "type": "string",
+        "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+      }
     },
     "order_format": {
       "description": "The purchase order line format",


### PR DESCRIPTION
## Purpose
[MODORDERS-154](https://issues.folio.org/browse/MODORDERS-154) PO Line: make location details repeatable

## Approach
* Replace single location by array of location objects in composite PO Line schema
* Replace single location uuid by array of location uuid's in PO Line schema
* Update samples

#### TODO
The PR can be merged only once changes are ready for following repositories
- [x] [mod-orders](https://github.com/folio-org/mod-orders) - [MODORDERS-154](https://issues.folio.org/browse/MODORDERS-154)
- [x] [mod-orders-storage](https://github.com/folio-org/mod-orders-storage) - [MODORDSTOR-53](https://issues.folio.org/browse/MODORDSTOR-53)
- [x] [mod-gobi](https://github.com/folio-org/mod-gobi) - [MODGOBI-48](https://issues.folio.org/browse/MODGOBI-48)