### PR TITLE
MODORDERS-93 po_line_number isn't set when creating a new po_line

### DIFF
--- a/composite_po_line.json
+++ b/composite_po_line.json
@@ -178,7 +178,8 @@
     "po_line_number": {
       "description": "A human readable number assigned to this PO line",
       "type": "string",
-      "pattern": "^[a-zA-Z0-9]{5,16}-[0-9]{1,3}$"
+      "pattern": "^[a-zA-Z0-9]{5,16}-[0-9]{1,3}$",
+      "readonly": true
     },
     "publication_date": {
       "description": "date (year) of the material's publication",


### PR DESCRIPTION
## Purpose
[MODORDERS-93](https://issues.folio.org/browse/MODORDERS-93)
The goal is to disable the ability to set a value for "po_line_number" using put and post requests

## Approach
- made "po_line_number" field readonly for compositePoLine

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Examples exist for all schemas
  - [ ] Descriptions exist for all schema properties
  - [ ] All schemas pass raml-cop linting
- Does this introduce breaking changes?
  - [ ] Were there any schema changes?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
