### PR TITLE
MODORDERS-103 Implement receiving flow for physical resource

### DIFF
--- a/mod-orders/examples/receivingCollection.sample
+++ b/mod-orders/examples/receivingCollection.sample
@@ -8,6 +8,7 @@
           "barcode": "0987654321",
           "comment": "Very important note",
           "caption": "Vol. 1",
+          "itemStatus": "Received",
           "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
           "pieceId": "c18c49b7-d970-44d6-b5d4-bd76c1c62d83"
         },
@@ -15,7 +16,8 @@
           "barcode": "0987654111",
           "comment": "Very important note",
           "caption": "Vol. 2",
-          "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6"
+          "itemStatus": "Received",
+          "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
           "pieceId": "cb9b0468-f2b4-4a13-b64c-662c4c9ec3ed"
         }
       ]
@@ -28,7 +30,8 @@
           "barcode": "0987654333",
           "comment": "Very important note",
           "caption": "Vol. 286",
-          "locationId": "279f42ce-17d1-463e-b890-deeebd1baeee"
+          "itemStatus": "In transit",
+          "locationId": "279f42ce-17d1-463e-b890-deeebd1baeee",
           "pieceId": "20241b8c-9076-4cf5-817b-f2c1e2cb242f"
         }
       ]

--- a/mod-orders/examples/receivingResults.sample
+++ b/mod-orders/examples/receivingResults.sample
@@ -15,7 +15,10 @@
           "pieceId": "cb9b0468-f2b4-4a13-b64c-662c4c9ec3ed",
           "processingStatus": {
             "type": "failure",
-            "message": "The item has not been updated in the inventory"
+            "error": {
+              "code": "pieceAlreadyReceived",
+              "message": "The piece record is already received"
+            }
           }
         }
       ]

--- a/mod-orders/schemas/receivingCollection.json
+++ b/mod-orders/schemas/receivingCollection.json
@@ -38,6 +38,10 @@
                   "description": "The volume or caption of the item",
                   "type": "string"
                 },
+                "itemStatus": {
+                  "description": "The status of the item",
+                  "type": "string"
+                },
                 "locationId": {
                   "description": "The id of the location",
                   "type": "string",
@@ -50,6 +54,7 @@
                 }
               },
               "required": [
+                "itemStatus",
                 "pieceId"
               ],
               "additionalProperties": false

--- a/mod-orders/schemas/receivingResults.json
+++ b/mod-orders/schemas/receivingResults.json
@@ -47,9 +47,11 @@
                         "failure"
                       ]
                     },
-                    "message": {
-                      "description": "The message describing processed piece record",
-                      "type": "string"
+                    "error": {
+                      "description": "Error details in case receiving process for the piece record has failed",
+                      "type": "object",
+                      "$ref": "../../../raml-util/schemas/error.schema",
+                      "readonly": true
                     }
                   },
                   "required": [


### PR DESCRIPTION
## Purpose
[MODORDERS-103](https://issues.folio.org/browse/MODORDERS-103) Implement receiving flow for physical resources
Please see [Update Item Details sketch](https://sketch.cloud/s/RMywj/4ax51jq/play). User can specify desired item status. Receiving API should accept the status.

## Approach
Adding desired items status to the receiving collection

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Examples exist for all schemas
  - [x] Descriptions exist for all schema properties
  - [x] All schemas pass raml-cop linting
- Does this introduce breaking changes?
  - [ ] Were there any schema changes?
  - [ ] There are no breaking changes in this PR.