### PR TITLE
MODORDSTOR-70 - Make poLine.checkinItems default to false

### DIFF
--- a/mod-orders-storage/schemas/po_line.json
+++ b/mod-orders-storage/schemas/po_line.json
@@ -14,7 +14,8 @@
     },
     "checkinItems": {
       "description": "if true this will toggle the Check-in workflow for details associated with this PO line",
-      "type": "boolean"
+      "type": "boolean",
+      "default": false
     },
     "instanceId": {
       "description": "UUID of the instance record this purchase order line is related to",

--- a/mod-orders/examples/composite_purchase_orders.sample
+++ b/mod-orders/examples/composite_purchase_orders.sample
@@ -34,6 +34,7 @@
       "compositePoLines": [
         {
           "id": "f97355de-9a18-4bbb-ac47-066d6a52e27a",
+          "checkinItems": false,
           "cost": {
             "additionalCost": 2.00,
             "currency": "USD",
@@ -49,6 +50,7 @@
         },
         {
           "id": "d51772fd-582e-41bd-9073-712f5fb399f1",
+          "checkinItems": false,
           "cost": {
             "currency": "USD",
             "discount": 2.00,

--- a/mod-orders/schemas/composite_po_line.json
+++ b/mod-orders/schemas/composite_po_line.json
@@ -14,7 +14,8 @@
     },
     "checkinItems": {
       "description": "if true this will toggle the Check-in workflow for details associated with this PO line",
-      "type": "boolean"
+      "type": "boolean",
+      "default": false
     },
     "instanceId": {
       "description": "UUID of the instance record this purchase order line is related to",


### PR DESCRIPTION
[MODORDSTOR-70](https://issues.folio.org/browse/MODORDSTOR-70) - Make poLine.checkinItems default to false

## Purpose
The poLine and compositePoLine schemas should be updated to use a default of false to avoid confusion when poLine.checkinItems field is omitted and won't appear in the receiving history for that poLine.

## Approach
po_line.json/composite_po_line.json schemas updating -> checkinItems: default value setted to false

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Examples exist for all schemas
  - [x] Descriptions exist for all schema properties
  - [x] All schemas pass raml-cop linting
- Does this introduce breaking changes?
  - [ ] Were there any schema changes?
  - [x] There are no breaking changes in this PR.