### PR TITLE
MODINVOSTO-4 - Implement Basic CRUD APIs for invoice-lines

### DIFF
--- a/mod-invoice-storage/examples/invoice_line.sample
+++ b/mod-invoice-storage/examples/invoice_line.sample
@@ -12,7 +12,7 @@
   "invoiceLineTax": 11.2,
   "comment": "Sample invoice line",
   "price": 2.2,
-  "quantity": 3.0,
+  "quantity": 3,
   "doNotReleaseEncumbrance": true,
   "reportTax": 3.5,
   "subscriptionInfo": "Subscription information",

--- a/mod-invoice-storage/schemas/invoice_line.json
+++ b/mod-invoice-storage/schemas/invoice_line.json
@@ -24,8 +24,7 @@
     },
     "invoiceLineNumber": {
       "description": "Sequentially generated and not editable by the user.",
-      "type": "string",
-      "readonly": true
+      "type": "string"
     },
     "invoiceLineStatus": {
       "description": "Invoice line status",


### PR DESCRIPTION
[MODINVOSTO-4](https://issues.folio.org/browse/MODINVOSTO-4) - Implement Basic CRUD APIs for invoice-lines

## Purpose

According to story requirements one need to allow save "invoiceLineNumber" in the storage. This means one need to make this field not only for reading.

Note: additionally updated example for invoice_line.sample - as per schema "quantity" field should be integer.

## Approach
Remove modifier "readOnly": true for "invoiceLineNumber" field in the invoice_line.json schema

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Examples exist for all schemas
  - [x] Descriptions exist for all schema properties
  - [x] All schemas pass raml-cop linting
- Does this introduce breaking changes?
  - [x] Were there any schema changes?
**"mod-invoice-storage", "mod-invoice"**
  - [x] There are no breaking changes in this PR.