### PR TITLE
MODORDERS-211 Align POL Payment and Receipt status with PO Status when opening order

### DIFF
--- a/mod-orders-storage/schemas/po_line.json
+++ b/mod-orders-storage/schemas/po_line.json
@@ -145,7 +145,8 @@
         "Partially Paid",
         "Payment Not Required",
         "Pending"
-      ]
+      ],
+      "default": "Pending"
     },
     "physical": {
       "description": "UUID of the physical (details) record",

--- a/mod-orders/schemas/composite_po_line.json
+++ b/mod-orders/schemas/composite_po_line.json
@@ -145,7 +145,8 @@
         "Partially Paid",
         "Payment Not Required",
         "Pending"
-      ]
+      ],
+      "default": "Pending"
     },
     "physical": {
       "description": "details of this purchase order line relating to physical materials",


### PR DESCRIPTION
## Purpose
[MODORDERS-211](https://issues.folio.org/browse/MODORDERS-211) POL paymentStatus should be updated when opening an order.

## Approach
made paymentStatus default "Pending"

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Examples exist for all schemas
  - [x] Descriptions exist for all schema properties
  - [x] All schemas pass raml-cop linting
- Does this introduce breaking changes?
  - [x] Were there any schema changes?
  - [x] There are no breaking changes in this PR. 
