### PR TITLE
MODORGS-26 Country should not be a required field

### DIFF
--- a/mod-orgs/schemas/address.json
+++ b/mod-orgs/schemas/address.json
@@ -49,8 +49,5 @@
       "type": "string"
     }
   },
-  "additionalProperties": false,
-  "required": [
-    "country"
-  ]
+  "additionalProperties": false
 }


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/MODORGS-26

## Approach
* making address country field not required

#### TODOS and Open Questions
Also was found that `addressLine1` field is required according to [Acquisitions Interface Fields](https://docs.google.com/spreadsheets/d/1F88PoSnEKD7oFnza1ZuOgzAgKnK95XOyTQzxyww3tZA/edit#gid=2127691361&range=C13), but currently this field is not required.


## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Examples exist for all schemas
  - [ ] Descriptions exist for all schema properties
  - [ ] All schemas pass raml-cop linting
- Does this introduce breaking changes?
  - [ ] Were there any schema changes?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
