### PR TITLE
MODORDERS-243 Make budget id in encumbrance optional

### DIFF
--- a/mod-finance/schemas/encumbrance.json
+++ b/mod-finance/schemas/encumbrance.json
@@ -52,7 +52,6 @@
   "additionalProperties": false,
   "required": [
     "amountEncumbered",
-    "budgetId",
     "fundId",
     "poLineId"
   ]


### PR DESCRIPTION
## Purpose
[MODORDERS-243](https://issues.folio.org/browse/MODORDERS-243) Create encumbrance upon order transition to "Open"

## Approach
Making `budgetId` optional - the orders app has only fund distribution which has only fundId

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Examples exist for all schemas
  - [ ] Descriptions exist for all schema properties
  - [ ] All schemas pass raml-cop linting
- Does this introduce breaking changes?
  - [ ] Were there any schema changes?
  - [x] There are no breaking changes in this PR.
