### PR TITLE
MODORDERS-252: Make productIdType to be uuid (acq-model)

### DIFF
--- a/common/schemas/product_id_type.json
+++ b/common/schemas/product_id_type.json
@@ -1,19 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "description": "the type of product id",
+  "description": "The UUID corresponding to the type of product id",
   "type": "string",
-  "enum": [
-    "ISBN",
-    "ISSN",
-    "ISMN",
-    "EAN",
-    "Other Standard Identifier",
-    "Standard Technical Report Number",
-    "Publisher Number",
-    "CODEN",
-    "GPO Item Number",
-    "Locally-defined identifiers",
-    "Vendor Title Number",
-    "Vendor Item Number"
-  ]
+  "pattern": "^[a-f0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
 }

--- a/common/schemas/product_id_type.json
+++ b/common/schemas/product_id_type.json
@@ -2,5 +2,5 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "The UUID corresponding to the type of product id",
   "type": "string",
-  "pattern": "^[a-f0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+  "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
 }

--- a/mod-invoice-storage/examples/invoice_line.sample
+++ b/mod-invoice-storage/examples/invoice_line.sample
@@ -47,7 +47,7 @@
   "invoiceLineStatus": "Open",
   "poLineId": "e8971620-8ee4-4f3b-b5b5-93b864df16ed",
   "productId": "9780764354113",
-  "productIdType": "ISBN",
+  "productIdType": "368757b8-6fe2-4989-b08e-5328cc2c291a",
   "quantity": 3,
   "releaseEncumbrance": true,
   "subscriptionInfo": "Subscription information",

--- a/mod-invoice-storage/examples/invoice_line.sample
+++ b/mod-invoice-storage/examples/invoice_line.sample
@@ -47,7 +47,7 @@
   "invoiceLineStatus": "Open",
   "poLineId": "e8971620-8ee4-4f3b-b5b5-93b864df16ed",
   "productId": "9780764354113",
-  "productIdType": "368757b8-6fe2-4989-b08e-5328cc2c291a",
+  "productIdType": "8261054f-be78-422d-bd51-4ed9f33c3422",
   "quantity": 3,
   "releaseEncumbrance": true,
   "subscriptionInfo": "Subscription information",

--- a/mod-invoice-storage/examples/invoice_line_collection.sample
+++ b/mod-invoice-storage/examples/invoice_line_collection.sample
@@ -34,7 +34,7 @@
       "invoiceLineStatus": "Open",
       "vendorRefNo": "2019-184",
       "productId": "9780764354113",
-      "productIdType": "ISBN",
+      "productIdType": "368757b8-6fe2-4989-b08e-5328cc2c291a",
       "comment": "Sample invoice line",
       "quantity": 3,
       "releaseEncumbrance": true,

--- a/mod-invoice-storage/examples/invoice_line_collection.sample
+++ b/mod-invoice-storage/examples/invoice_line_collection.sample
@@ -34,7 +34,7 @@
       "invoiceLineStatus": "Open",
       "vendorRefNo": "2019-184",
       "productId": "9780764354113",
-      "productIdType": "368757b8-6fe2-4989-b08e-5328cc2c291a",
+      "productIdType": "8261054f-be78-422d-bd51-4ed9f33c3422",
       "comment": "Sample invoice line",
       "quantity": 3,
       "releaseEncumbrance": true,

--- a/mod-orders-storage/examples/po_line_collection.sample
+++ b/mod-orders-storage/examples/po_line_collection.sample
@@ -41,7 +41,7 @@
           "productIds": [
             {
               "productId": "9780764354113",
-              "productIdType": "ISBN"
+              "productIdType": "368757b8-6fe2-4989-b08e-5328cc2c291a"
             }
           ],
           "subscriptionFrom": "2018-10-09T00:00:00.000Z",

--- a/mod-orders-storage/examples/po_line_collection.sample
+++ b/mod-orders-storage/examples/po_line_collection.sample
@@ -41,7 +41,7 @@
           "productIds": [
             {
               "productId": "9780764354113",
-              "productIdType": "368757b8-6fe2-4989-b08e-5328cc2c291a"
+              "productIdType": "8261054f-be78-422d-bd51-4ed9f33c3422"
             }
           ],
           "subscriptionFrom": "2018-10-09T00:00:00.000Z",

--- a/mod-orders-storage/examples/po_line_get.sample
+++ b/mod-orders-storage/examples/po_line_get.sample
@@ -41,7 +41,7 @@
     "productIds": [
       {
         "productId": "9780764354113",
-        "productIdType": "ISBN"
+        "productIdType": "368757b8-6fe2-4989-b08e-5328cc2c291a"
       }
     ],
     "subscriptionFrom": "2018-10-09T00:00:00.000Z",

--- a/mod-orders-storage/examples/po_line_get.sample
+++ b/mod-orders-storage/examples/po_line_get.sample
@@ -41,7 +41,7 @@
     "productIds": [
       {
         "productId": "9780764354113",
-        "productIdType": "368757b8-6fe2-4989-b08e-5328cc2c291a"
+        "productIdType": "8261054f-be78-422d-bd51-4ed9f33c3422"
       }
     ],
     "subscriptionFrom": "2018-10-09T00:00:00.000Z",

--- a/mod-orders-storage/examples/po_line_post.sample
+++ b/mod-orders-storage/examples/po_line_post.sample
@@ -38,7 +38,7 @@
     "productIds": [
       {
         "productId": "9780764354113",
-        "productIdType": "ISBN"
+        "productIdType": "368757b8-6fe2-4989-b08e-5328cc2c291a"
       }
     ],
     "subscriptionFrom": "2018-10-09T00:00:00.000Z",

--- a/mod-orders-storage/examples/po_line_post.sample
+++ b/mod-orders-storage/examples/po_line_post.sample
@@ -38,7 +38,7 @@
     "productIds": [
       {
         "productId": "9780764354113",
-        "productIdType": "368757b8-6fe2-4989-b08e-5328cc2c291a"
+        "productIdType": "8261054f-be78-422d-bd51-4ed9f33c3422"
       }
     ],
     "subscriptionFrom": "2018-10-09T00:00:00.000Z",

--- a/mod-orders/examples/composite_po_line.sample
+++ b/mod-orders/examples/composite_po_line.sample
@@ -44,7 +44,7 @@
     "productIds": [
       {
         "productId": "9780764354113",
-        "productIdType": "ISBN"
+        "productIdType": "368757b8-6fe2-4989-b08e-5328cc2c291a"
       }
     ],
     "subscriptionFrom": "2018-10-09T00:00:00.000Z",

--- a/mod-orders/examples/composite_po_line.sample
+++ b/mod-orders/examples/composite_po_line.sample
@@ -44,7 +44,7 @@
     "productIds": [
       {
         "productId": "9780764354113",
-        "productIdType": "368757b8-6fe2-4989-b08e-5328cc2c291a"
+        "productIdType": "8261054f-be78-422d-bd51-4ed9f33c3422"
       }
     ],
     "subscriptionFrom": "2018-10-09T00:00:00.000Z",

--- a/mod-orders/examples/composite_purchase_order.sample
+++ b/mod-orders/examples/composite_purchase_order.sample
@@ -80,7 +80,7 @@
         "productIds": [
           {
             "productId": "9780764354113",
-            "productIdType": "ISBN"
+            "productIdType": "368757b8-6fe2-4989-b08e-5328cc2c291a"
           }
         ],
         "subscriptionFrom": "2018-10-09T00:00:00.000Z",

--- a/mod-orders/examples/composite_purchase_order.sample
+++ b/mod-orders/examples/composite_purchase_order.sample
@@ -80,7 +80,7 @@
         "productIds": [
           {
             "productId": "9780764354113",
-            "productIdType": "368757b8-6fe2-4989-b08e-5328cc2c291a"
+            "productIdType": "8261054f-be78-422d-bd51-4ed9f33c3422"
           }
         ],
         "subscriptionFrom": "2018-10-09T00:00:00.000Z",


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODGOBI-43 Move "Renewals" information to Purchase Order level

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders 
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-138
 -->
https://issues.folio.org/browse/MODORDERS-252

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
There are 2 ways to do this:
1. Update this schema as done in this PR
2. Delete product_id_type.json completely and update each schema where it is used

Currently, `product_id_type.json` is used in 2 places `mod-orders-storage/schemas/details.json` and `mod-invoice-storage/schemas/invoice_line.json` So, I will go ahead with option 1 so that will keep our options open in case other modules decide to use `product_type_id` in future. Other modules can just ref it.

- Update examples

Note - This PR will not be merged until mod-order-storage and mod-orders are ready.

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Examples exist for all schemas
  - [x] Descriptions exist for all schema properties
  - [x] All schemas pass raml-cop linting
- Does this introduce breaking changes?
  - [ ] Were there any schema changes?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
