### PR TITLE
MODINVOSTO-24 add billTo and exportToAccounting properties

### DIFF
--- a/mod-invoice-storage/examples/invoice.sample
+++ b/mod-invoice-storage/examples/invoice.sample
@@ -28,6 +28,7 @@
   "adjustmentsTotal": 14.50,
   "chkSubscriptionOverlap": false,
   "currency": "USD",
+  "exportToAccounting": true,
   "folioInvoiceNo": "123invoicenumber45",
   "invoiceDate": "2018-07-20T00:00:00.000+0000",
   "lockTotal": true,

--- a/mod-invoice-storage/examples/invoice_collection.sample
+++ b/mod-invoice-storage/examples/invoice_collection.sample
@@ -15,6 +15,7 @@
       "adjustmentsTotal": 4.50,
       "approvedBy": "ab18897b-0e40-4f31-896b-9c9adc979a88",
       "approvalDate": "2018-07-29T00:00:00.000+0000",
+      "billTo": "1df71bab-818c-46ea-988b-a23676d91ae6",
       "chkSubscriptionOverlap": false,
       "currency": "USD",
       "folioInvoiceNo": "123invoicenumber45",

--- a/mod-invoice-storage/schemas/invoice.json
+++ b/mod-invoice-storage/schemas/invoice.json
@@ -31,6 +31,11 @@
       "type": "string",
       "format": "date-time"
     },
+    "billTo": {
+      "description": "UUID of the billing address",
+      "type": "string",
+      "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+    },
     "chkSubscriptionOverlap": {
       "description": "IF TRUE the system will check if there is another invoice for this subscription and whether the dates overlap. IF the dates overlap, the system should issue an alert.",
       "type": "boolean"
@@ -38,6 +43,11 @@
     "currency":{
       "description": "Ideally this is the ISO code and not something the user defines",
       "type": "string"
+    },
+    "exportToAccounting": {
+      "description": "This would keep the invoice from being feed into the batch process (i.e. not generate an external voucher/payment) but would still move values in the system. This might be defined by the vendor relationship and exposed for override on the invoice.",
+      "type": "boolean",
+      "default": false
     },
     "folioInvoiceNo": {
       "description": "Invoice number in folio system",


### PR DESCRIPTION
## Purpose
[MODINVOSTO-24](https://issues.folio.org/browse/MODINVOSTO-24) add billTo and exportToAccounting properties

## Approach
Adding 2 new properties to invoice.json schema

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Examples exist for all schemas
  - [x] Descriptions exist for all schema properties
  - [x] All schemas pass raml-cop linting
- Does this introduce breaking changes?
  - [x] Were there any schema changes?
  - [x] There are no breaking changes in this PR.