### PR TITLE
MODORDSTOR-98 filterable boolean properties to have default value

### DIFF
--- a/mod-orders-storage/schemas/claim.json
+++ b/mod-orders-storage/schemas/claim.json
@@ -5,7 +5,8 @@
   "properties": {
     "claimed": {
       "description": "whether or not this purchase order line has been claimed",
-      "type": "boolean"
+      "type": "boolean",
+      "default": false
     },
     "sent": {
       "description": "date a claim was sent",

--- a/mod-orders-storage/schemas/eresource.json
+++ b/mod-orders-storage/schemas/eresource.json
@@ -5,7 +5,8 @@
   "properties": {
     "activated": {
       "description": "whether or not this resource is activated",
-      "type": "boolean"
+      "type": "boolean",
+      "default": false
     },
     "activationDue": {
       "description": "number of days until activation, from date of order placement",
@@ -23,7 +24,8 @@
     },
     "trial": {
       "description": "whether or not this is a trial",
-      "type": "boolean"
+      "type": "boolean",
+      "default": false
     },
     "expectedActivation": {
       "description": "expected date the resource will be activated",

--- a/mod-orders-storage/schemas/po_line.json
+++ b/mod-orders-storage/schemas/po_line.json
@@ -72,7 +72,8 @@
     },
     "collection": {
       "description": "whether or not this purchase order line is for a collection",
-      "type": "boolean"
+      "type": "boolean",
+      "default": false
     },
     "contributors": {
       "description": "list of contributors to the material",
@@ -201,7 +202,8 @@
     },
     "rush": {
       "description": "whether or not this is a rush order",
-      "type": "boolean"
+      "type": "boolean",
+      "default": false
     },
     "selector": {
       "description": "who selected this material",

--- a/mod-orders-storage/schemas/purchase_order.json
+++ b/mod-orders-storage/schemas/purchase_order.json
@@ -10,7 +10,8 @@
     },
     "approved": {
       "description": "whether or not the purchase order has been approved",
-      "type": "boolean"
+      "type": "boolean",
+      "default": false
     },
     "assignedTo": {
       "description": "UUID of the user this purchase order his assigned to",
@@ -63,7 +64,8 @@
     },
     "reEncumber": {
       "description": "indicates this purchase order should be re-encumbered each fiscal year. Only applies to ongoing orders",
-      "type": "boolean"
+      "type": "boolean",
+      "default": false
     },
     "renewal": {
       "description": "Renewal information associated with this order",

--- a/mod-orders-storage/schemas/renewal.json
+++ b/mod-orders-storage/schemas/renewal.json
@@ -21,7 +21,8 @@
     },
     "manualRenewal": {
       "description": "whether or not this is a manual renewal",
-      "type": "boolean"
+      "type": "boolean",
+      "default": false
     },
     "reviewPeriod": {
       "description": "time prior to renewal where changes can be made to subscription",


### PR DESCRIPTION
## Purpose
[MODORDSTOR-98](https://issues.folio.org/browse/MODORDSTOR-98) filterable `boolean` properties should have default value

## Approach
Adding default value for `boolean` properties which have Y in "Filter on this?" column in [Acquisitions Interface Fields - Orders](https://docs.google.com/spreadsheets/d/1F88PoSnEKD7oFnza1ZuOgzAgKnK95XOyTQzxyww3tZA/edit#gid=1408113181)

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Examples exist for all schemas
  - [ ] Descriptions exist for all schema properties
  - [ ] All schemas pass raml-cop linting
- Does this introduce breaking changes?
  - [ ] Were there any schema changes?
  - [x] There are no breaking changes in this PR.
