### PR TITLE
MODORDERS-251 - Restrict creation of PO, POL, Piece records based upon acquisitions unit

### DIFF
--- a/common/schemas/uuid.json
+++ b/common/schemas/uuid.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "The UUID format string",
+  "type": "string",
+  "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+}

--- a/mod-orders-storage/examples/purchase_order_collection.sample
+++ b/mod-orders-storage/examples/purchase_order_collection.sample
@@ -34,6 +34,10 @@
              "important"
          ]
       },
+      "acqUnitIds": [
+        "1895e539-8dac-441e-b1f5-aab62b3fde60",
+        "47f504bd-0c1b-498e-a2ae-e2f0a0cea273"
+      ],
       "metadata": {
         "createdDate": "2018-07-19T00:00:00.000+0000",
         "createdByUserId": "28d1057c-d137-11e8-a8d5-f2801f1b9fd1"

--- a/mod-orders-storage/examples/purchase_order_collection.sample
+++ b/mod-orders-storage/examples/purchase_order_collection.sample
@@ -28,6 +28,10 @@
       "shipTo": "0830111e-dcf1-4897-9eee-dcd1ab44adce",
       "template": "678323d2-3d86-4a69-8674-bbd4f8eecb33",
       "vendor": "168f8a86-d26c-406e-813f-c7527f241ac3",
+      "units": [
+        "1895e539-8dac-441e-b1f5-aab62b3fde60",
+        "47f504bd-0c1b-498e-a2ae-e2f0a0cea273"
+      ],
       "workflowStatus": "Pending",
       "metadata": {
         "createdDate": "2018-07-19T00:00:00.000+0000",

--- a/mod-orders-storage/examples/purchase_order_get.sample
+++ b/mod-orders-storage/examples/purchase_order_get.sample
@@ -33,6 +33,10 @@
           "important"
       ]
   },
+  "acqUnitIds": [
+    "1895e539-8dac-441e-b1f5-aab62b3fde60",
+    "47f504bd-0c1b-498e-a2ae-e2f0a0cea273"
+  ],
   "metadata": {
     "createdDate": "2018-08-19T00:00:00.000+0000",
     "createdByUserId": "28d1057c-d137-11e8-a8d5-f2801f1b9fd1"

--- a/mod-orders-storage/examples/purchase_order_get.sample
+++ b/mod-orders-storage/examples/purchase_order_get.sample
@@ -27,6 +27,10 @@
   "shipTo": "0830111e-dcf1-4897-9eee-dcd1ab44adce",
   "template": "678323d2-3d86-4a69-8674-bbd4f8eecb33",
   "vendor": "168f8a86-d26c-406e-813f-c7527f241ac3",
+  "units": [
+    "1895e539-8dac-441e-b1f5-aab62b3fde60",
+    "47f504bd-0c1b-498e-a2ae-e2f0a0cea273"
+  ],
   "workflowStatus": "Closed",
   "metadata": {
     "createdDate": "2018-08-19T00:00:00.000+0000",

--- a/mod-orders-storage/examples/purchase_order_post.sample
+++ b/mod-orders-storage/examples/purchase_order_post.sample
@@ -26,5 +26,9 @@
     "tagList" : [
       "important"
       ]
-   }
+   },
+  "acqUnitIds": [
+    "1895e539-8dac-441e-b1f5-aab62b3fde60",
+    "47f504bd-0c1b-498e-a2ae-e2f0a0cea273"
+  ]
 }

--- a/mod-orders-storage/examples/purchase_order_post.sample
+++ b/mod-orders-storage/examples/purchase_order_post.sample
@@ -21,5 +21,9 @@
   "shipTo": "0830111e-dcf1-4897-9eee-dcd1ab44adce",
   "template": "678323d2-3d86-4a69-8674-bbd4f8eecb33",
   "vendor": "168f8a86-d26c-406e-813f-c7527f241ac3",
+  "units": [
+    "1895e539-8dac-441e-b1f5-aab62b3fde60",
+    "47f504bd-0c1b-498e-a2ae-e2f0a0cea273"
+  ],
   "workflowStatus": "Pending"
 }

--- a/mod-orders-storage/schemas/purchase_order.json
+++ b/mod-orders-storage/schemas/purchase_order.json
@@ -93,6 +93,14 @@
       ],
       "default": "Pending"
     },
+    "acqUnitIds": {
+      "description": "acquisition unit ids associated with this purchase order",
+      "id": "units",
+      "type": "array",
+      "items": {
+        "$ref": "../../common/schemas/uuid.json"
+      }
+    },
     "tags": {
       "type": "object",
       "description": "arbitrary tags associated with this purchase order",

--- a/mod-orders-storage/schemas/purchase_order.json
+++ b/mod-orders-storage/schemas/purchase_order.json
@@ -78,6 +78,14 @@
       "type": "string",
       "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
     },
+    "units": {
+      "description": "unit ids associated with this purchase order",
+      "id": "units",
+      "type": "array",
+      "items": {
+        "$ref": "../../common/schemas/uuid.json"
+      }
+    },
     "vendor": {
       "description": "UUID of the vendor record",
       "type": "string",

--- a/mod-orders/examples/composite_purchase_order.sample
+++ b/mod-orders/examples/composite_purchase_order.sample
@@ -167,6 +167,10 @@
         "ABCDEFGHIJKLMNO"
       ],
       "title": "Kayak Fishing in the Northern Gulf Coast",
+      "units": [
+        "1895e539-8dac-441e-b1f5-aab62b3fde60",
+        "47f504bd-0c1b-498e-a2ae-e2f0a0cea273"
+      ],
       "vendorDetail": {
         "instructions": "ABCDEFG",
         "noteFromVendor": "ABCDEFGHIKJKLMNOP",

--- a/mod-orders/examples/composite_purchase_order.sample
+++ b/mod-orders/examples/composite_purchase_order.sample
@@ -167,7 +167,7 @@
         "ABCDEFGHIJKLMNO"
       ],
       "title": "Kayak Fishing in the Northern Gulf Coast",
-      "units": [
+      "acqUnitIds": [
         "1895e539-8dac-441e-b1f5-aab62b3fde60",
         "47f504bd-0c1b-498e-a2ae-e2f0a0cea273"
       ],

--- a/mod-orders/examples/composite_purchase_orders.sample
+++ b/mod-orders/examples/composite_purchase_orders.sample
@@ -28,6 +28,10 @@
       "template": "678323d2-3d86-4a69-8674-bbd4f8eecb33",
       "totalEstimatedPrice": 103.47,
       "totalItems": 5,
+      "units": [
+        "1895e539-8dac-441e-b1f5-aab62b3fde60",
+        "47f504bd-0c1b-498e-a2ae-e2f0a0cea273"
+      ],
       "vendor": "168f8a86-d26c-406e-813f-c7527f241ac3",
       "workflowStatus": "Open",
       "metadata": {

--- a/mod-orders/examples/composite_purchase_orders.sample
+++ b/mod-orders/examples/composite_purchase_orders.sample
@@ -28,7 +28,7 @@
       "template": "678323d2-3d86-4a69-8674-bbd4f8eecb33",
       "totalEstimatedPrice": 103.47,
       "totalItems": 5,
-      "units": [
+      "acqUnitIds": [
         "1895e539-8dac-441e-b1f5-aab62b3fde60",
         "47f504bd-0c1b-498e-a2ae-e2f0a0cea273"
       ],

--- a/mod-orders/schemas/composite_purchase_order.json
+++ b/mod-orders/schemas/composite_purchase_order.json
@@ -109,8 +109,8 @@
         "$ref": "composite_po_line.json"
       }
     },
-    "units": {
-      "description": "unit ids associated with this purchase order",
+    "acqUnitIds": {
+      "description": "acquisition unit ids associated with this purchase order",
       "id": "units",
       "type": "array",
       "items": {

--- a/mod-orders/schemas/composite_purchase_order.json
+++ b/mod-orders/schemas/composite_purchase_order.json
@@ -116,6 +116,7 @@
       "items": {
         "$ref": "../../common/schemas/uuid.json"
       }
+    },
     "tags": {
       "type": "object",
       "description": "arbitrary tags associated with this purchase order",

--- a/mod-orders/schemas/composite_purchase_order.json
+++ b/mod-orders/schemas/composite_purchase_order.json
@@ -109,6 +109,14 @@
         "$ref": "composite_po_line.json"
       }
     },
+    "units": {
+      "description": "unit ids associated with this purchase order",
+      "id": "units",
+      "type": "array",
+      "items": {
+        "$ref": "../../common/schemas/uuid.json"
+      }
+    },
     "metadata": {
       "type": "object",
       "$ref": "../../../raml-util/schemas/metadata.schema",


### PR DESCRIPTION
[MODORDERS-251](https://issues.folio.org/browse/MODORDERS-251) - Restrict creation of PO, POL, Piece records based upon acquisitions unit.

## Purpose
In scope of [MODORDERS-251](https://issues.folio.org/browse/MODORDERS-251) one need to implement support of unit IDs array on composite po and purchase order schemes to  restrict managing of purchase order based on acquisition units.

## Approach
UUID type picked out to separate file uuid.json;
composite po schema contains array of IDs:
```
"units": {
      "description": "unit ids associated with this purchase order",
      "id": "units",
      "type": "array",
      "items": {
        "$ref": "../../common/schemas/uuid.json"
      }
    }
```

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Examples exist for all schemas
  - [x] Descriptions exist for all schema properties
  - [x] All schemas pass raml-cop linting
- Does this introduce breaking changes?
  - [x] Were there any schema changes?
Composite purchase order/purchase order: added optional field - unit ids array.
  - [ ] There are no breaking changes in this PR.
