### PR TITLE
MODINVOSTO-28/MODINVOSTO-31 Add acqUnitIds to Invoice and Voucher schemes

### DIFF
--- a/mod-invoice-storage/examples/invoice.sample
+++ b/mod-invoice-storage/examples/invoice.sample
@@ -52,10 +52,14 @@
   "vendorId": "168f8a63-d612-406e-813f-c7527f241ac3",
   "manualPayment": true,
   "tags": {
-          "tagList": [
-          	"tag"
-   ]
+    "tagList": [
+      "tag"
+    ]
    },
+  "acqUnitIds": [
+    "1895e539-8dac-441e-b1f5-aab62b3fde60",
+    "47f504bd-0c1b-498e-a2ae-e2f0a0cea273"
+  ],
   "metadata": {
     "createdDate": "2018-07-19T00:00:00.000+0000",
     "createdByUserId": "28d1057c-d137-11e8-a8d5-f2801f1b9fd1"

--- a/mod-invoice-storage/examples/invoice_collection.sample
+++ b/mod-invoice-storage/examples/invoice_collection.sample
@@ -41,10 +41,14 @@
       "vendorId": "168f8a63-d612-406e-813f-c7527f241ac3",
       "manualPayment": true,
       "tags": {
-          "tagList": [
-            "tag"
-       ]
+        "tagList": [
+          "tag"
+        ]
       },
+      "acqUnitIds": [
+        "1895e539-8dac-441e-b1f5-aab62b3fde60",
+        "47f504bd-0c1b-498e-a2ae-e2f0a0cea273"
+      ],
       "metadata": {
         "createdDate": "2018-07-19T00:00:00.000+0000",
         "createdByUserId": "28d1057c-d137-11e8-a8d5-f2801f1b9fd1"

--- a/mod-invoice-storage/examples/voucher.sample
+++ b/mod-invoice-storage/examples/voucher.sample
@@ -15,6 +15,10 @@
   "type": "Payment",
   "voucherDate": "2019-05-06T00:00:00.000+0000",
   "voucherNumber": "1000",
+  "acqUnitIds": [
+    "1895e539-8dac-441e-b1f5-aab62b3fde60",
+    "47f504bd-0c1b-498e-a2ae-e2f0a0cea273"
+  ],
   "metadata": {
     "createdDate": "2019-05-06T00:00:00.000+0000",
     "createdByUserId": "28d1057c-d137-11e8-a8d5-f2801f1b9fd1"

--- a/mod-invoice-storage/examples/voucher_collection.sample
+++ b/mod-invoice-storage/examples/voucher_collection.sample
@@ -17,6 +17,10 @@
       "type": "Pre-payment",
       "voucherDate": "2019-05-06T00:00:00.000+0000",
       "voucherNumber": "1000",
+      "acqUnitIds": [
+        "1895e539-8dac-441e-b1f5-aab62b3fde60",
+        "47f504bd-0c1b-498e-a2ae-e2f0a0cea273"
+      ],
       "metadata": {
          "createdDate": "2019-05-06T00:00:00.000+0000",
          "createdByUserId": "28d1057c-d137-11e8-a8d5-f2801f1b9fd1"

--- a/mod-invoice-storage/schemas/invoice.json
+++ b/mod-invoice-storage/schemas/invoice.json
@@ -154,6 +154,14 @@
       "description": "This would keep the invoice from being feed into the batch process (Not generate a external voucher/payment) but would still move values in the system. Note: this is ideally defined by the vendor relationship and exposed for override on the invoice.",
       "type": "boolean"
     },
+    "acqUnitIds": {
+      "description": "acquisition unit ids associated with this invoice",
+      "id": "units",
+      "type": "array",
+      "items": {
+        "$ref": "../../common/schemas/uuid.json"
+      }
+    },
     "metadata": {
       "type": "object",
       "$ref": "../../../raml-util/schemas/metadata.schema",

--- a/mod-invoice-storage/schemas/invoice.json
+++ b/mod-invoice-storage/schemas/invoice.json
@@ -156,7 +156,6 @@
     },
     "acqUnitIds": {
       "description": "acquisition unit ids associated with this invoice",
-      "id": "units",
       "type": "array",
       "items": {
         "$ref": "../../common/schemas/uuid.json"

--- a/mod-invoice-storage/schemas/voucher.json
+++ b/mod-invoice-storage/schemas/voucher.json
@@ -84,7 +84,6 @@
     },
     "acqUnitIds": {
       "description": "acquisition unit ids associated with this voucher",
-      "id": "units",
       "type": "array",
       "items": {
         "$ref": "../../common/schemas/uuid.json"

--- a/mod-invoice-storage/schemas/voucher.json
+++ b/mod-invoice-storage/schemas/voucher.json
@@ -82,6 +82,14 @@
       "type": "string",
       "pattern": "^[a-zA-Z0-9]*$"
     },
+    "acqUnitIds": {
+      "description": "acquisition unit ids associated with this voucher",
+      "id": "units",
+      "type": "array",
+      "items": {
+        "$ref": "../../common/schemas/uuid.json"
+      }
+    },
     "metadata": {
       "type": "object",
       "$ref": "../../../raml-util/schemas/metadata.schema",

--- a/mod-orders-storage/schemas/purchase_order.json
+++ b/mod-orders-storage/schemas/purchase_order.json
@@ -95,7 +95,6 @@
     },
     "acqUnitIds": {
       "description": "acquisition unit ids associated with this purchase order",
-      "id": "units",
       "type": "array",
       "items": {
         "$ref": "../../common/schemas/uuid.json"

--- a/mod-orders/schemas/composite_purchase_order.json
+++ b/mod-orders/schemas/composite_purchase_order.json
@@ -111,7 +111,6 @@
     },
     "acqUnitIds": {
       "description": "acquisition unit ids associated with this purchase order",
-      "id": "units",
       "type": "array",
       "items": {
         "$ref": "../../common/schemas/uuid.json"


### PR DESCRIPTION
## Purpose
[MODINVSTO-28](https://issues.folio.org/browse/MODINVOSTO-28)
[MODINVSTO-31](https://issues.folio.org/browse/MODINVOSTO-31)
According to [option 3](https://wiki.folio.org/display/FOLIJET/Acquisition+Units#AcquisitionUnits-OrderofOperations/Chicken&EggProblem), acquisitions-unit-assignments should become part of the invoice and voucher schemes.

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Examples exist for all schemas
  - [ ] Descriptions exist for all schema properties
  - [ ] All schemas pass raml-cop linting
- Does this introduce breaking changes?
  - [ ] Were there any schema changes?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
