### PR TITLE
MODORDERS-293 Acquisition units - soft delete

### DIFF
--- a/acquisitions-unit/examples/acquisitions_unit_collection.sample
+++ b/acquisitions-unit/examples/acquisitions_unit_collection.sample
@@ -3,6 +3,7 @@
      [
        {
           "name": "main",
+          "isDeleted": false,
           "protectCreate": true,
           "protectRead": false,
           "protectUpdate": true,
@@ -10,11 +11,20 @@
        },
        {
           "name": "law",
+          "isDeleted": false,
           "protectCreate": true,
           "protectRead": true,
           "protectUpdate": true,
           "protectDelete": true
+       },
+       {
+         "name": "general",
+         "isDeleted": true,
+         "protectCreate": false,
+         "protectRead": false,
+         "protectUpdate": false,
+         "protectDelete": false
        }
      ],
-   "totalRecords": 2
+   "totalRecords": 3
 }

--- a/acquisitions-unit/examples/acquisitions_unit_get.sample
+++ b/acquisitions-unit/examples/acquisitions_unit_get.sample
@@ -1,6 +1,7 @@
 {
   "id": "7ec2ed06-0504-40dc-bc53-7515955ff0cb",
   "name": "main",
+  "isDeleted": false,
   "protectCreate": true,
   "protectRead": false,
   "protectUpdate": true,

--- a/acquisitions-unit/examples/acquisitions_unit_post.sample
+++ b/acquisitions-unit/examples/acquisitions_unit_post.sample
@@ -1,5 +1,6 @@
 {
   "name": "main",
+  "isDeleted": false,
   "protectCreate": true,
   "protectRead": false,
   "protectUpdate": true,

--- a/acquisitions-unit/schemas/acquisitions_unit.json
+++ b/acquisitions-unit/schemas/acquisitions_unit.json
@@ -5,12 +5,16 @@
   "properties": {
     "id": {
       "description": "UUID of this acquisitions unit record",
-      "type": "string",
-      "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+      "$ref": "../../common/schemas/uuid.json"
     },
     "name": {
       "description": "a name for this acquisitions unit",
       "type": "string"
+    },
+    "isDeleted": {
+      "description": "If true, the record is marked for deletion at some point. This prevents it from being assigned to any record.",
+      "type": "boolean",
+      "default": false
     },
     "protectCreate": {
       "description": "if true, only members can create records associated with this acq unit.",
@@ -40,6 +44,7 @@
   },
   "additionalProperties": false,
   "required": [
-    "name"
+    "name",
+    "isDeleted"
   ]
 }


### PR DESCRIPTION
## Purpose
[MODORDERS-293](https://issues.folio.org/browse/MODORDERS-293) Acquisition units - soft delete
## Approach
Adding a `isDeleted` field to the acquisition_units schema - boolean, default: false, required.

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Examples exist for all schemas
  - [x] Descriptions exist for all schema properties
  - [x] All schemas pass raml-cop linting
- Does this introduce breaking changes?
  - [x] Were there any schema changes?
  - [ ] There are no breaking changes in this PR.