### PR TITLE
MODORDSTOR-109 Allow fund distributions to be specified as amount or percentage

### DIFF
--- a/mod-orders-storage/examples/po_line_collection.sample
+++ b/mod-orders-storage/examples/po_line_collection.sample
@@ -68,7 +68,8 @@
           {
             "code": "HIST",
             "fundId": "63157e96-0693-426d-b0df-948bacdfdb08",
-            "percentage": 80.0,
+            "distributionType": "percentage",
+            "value": 100.0,
             "encumbrance": "eb506834-6c70-4239-8d1a-6414a5b08ac3"
           }
         ],

--- a/mod-orders-storage/examples/po_line_get.sample
+++ b/mod-orders-storage/examples/po_line_get.sample
@@ -68,8 +68,16 @@
     {
       "code": "HIST",
       "fundId": "63157e96-0693-426d-b0df-948bacdfdb08",
-      "percentage": 80.0,
+      "distributionType": "percentage",
+      "value": 80.0,
       "encumbrance": "eb506834-6c70-4239-8d1a-6414a5b08ac3"
+    },
+    {
+      "code": "EUROHIST",
+      "fundId": "e9285a1c-1dfc-4380-868c-e74073003f43",
+      "distributionType": "amount",
+      "value": 13.34,
+      "encumbrance": "fb506834-6c70-4239-8d1a-6414a5b08ac3"
     }
   ],
   "locations": [

--- a/mod-orders-storage/examples/po_line_post.sample
+++ b/mod-orders-storage/examples/po_line_post.sample
@@ -51,7 +51,8 @@
     {
       "code": "HIST",
       "fundId": "63157e96-0693-426d-b0df-948bacdfdb08",
-      "percentage": 80.0,
+      "distributionType": "amount",
+      "value": 71.96,
       "encumbrance": "eb506834-6c70-4239-8d1a-6414a5b08ac3"
     }
   ],

--- a/mod-orders-storage/schemas/fund_distribution.json
+++ b/mod-orders-storage/schemas/fund_distribution.json
@@ -9,22 +9,30 @@
     },
     "encumbrance": {
       "description": "UUID of encumbrance record associated with this fund distribution",
-      "type": "string",
-      "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+      "$ref": "../../common/schemas/uuid.json"
     },
     "fundId": {
       "description": "UUID of the fund associated with this fund distribution",
-      "type": "string",
-      "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+      "$ref": "../../common/schemas/uuid.json"
     },
-    "percentage": {
-      "description": "the percentage of the cost to be applied to this fund",
+    "distributionType": {
+      "description": "Percentage or amount type of the value property",
+      "type": "string",
+      "enum": [
+        "amount",
+        "percentage"
+      ],
+      "default": "percentage"
+    },
+    "value": {
+      "description": "The value of the cost to be applied to this fund",
       "type": "number"
     }
   },
   "additionalProperties": false,
   "required": [
     "fundId",
-    "percentage"
+    "distributionType",
+    "value"
   ]
 }

--- a/mod-orders/examples/composite_po_line.sample
+++ b/mod-orders/examples/composite_po_line.sample
@@ -71,13 +71,15 @@
     {
       "code": "HIST",
       "fundId": "63157e96-0693-426d-b0df-948bacdfdb08",
-      "percentage": 80.0,
+      "distributionType": "percentage",
+      "value": 80.0,
       "encumbrance": "eb506834-6c70-4239-8d1a-6414a5b08ac3"
     },
     {
       "code": "GENRL",
       "fundId": "3652829d-a625-4c84-b297-9bd9955d6bc9",
-      "percentage": 20.0,
+      "distributionType": "amount",
+      "value": 33.09,
       "encumbrance": "0466cb77-0344-43c6-85eb-0a64aa2934e5"
     }
   ],

--- a/mod-orders/examples/composite_purchase_order.sample
+++ b/mod-orders/examples/composite_purchase_order.sample
@@ -95,13 +95,15 @@
         {
           "code": "HIST",
           "fundId": "63157e96-0693-426d-b0df-948bacdfdb08",
-          "percentage": 80.0,
+          "distributionType": "percentage",
+          "value": 80.0,
           "encumbrance": "eb506834-6c70-4239-8d1a-6414a5b08ac3"
         },
         {
           "code": "GENRL",
           "fundId": "3652829d-a625-4c84-b297-9bd9955d6bc9",
-          "percentage": 20.0,
+          "distributionType": "percentage",
+          "value": 20.0,
           "encumbrance": "0466cb77-0344-43c6-85eb-0a64aa2934e5"
         }
       ],


### PR DESCRIPTION
## Purpose
[MODORDSTOR-109](https://issues.folio.org/browse/MODORDSTOR-109) Allow fund distributions to be specified as amount or percentage

## Approach
Updating schema and samples

#### TODOS and Open Questions
- [ ] Can be merged when changes for [UIOR-370](https://issues.folio.org/browse/UIOR-370) are ready

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Examples exist for all schemas
  - [x] Descriptions exist for all schema properties
  - [x] All schemas pass raml-cop linting
- Does this introduce breaking changes?
  - [x] Were there any schema changes?
  - [ ] There are no breaking changes in this PR.
