### PR TITLE
MODORGS-43 Account record acquisition units

### DIFF
--- a/mod-orgs/examples/organization_collection.sample
+++ b/mod-orgs/examples/organization_collection.sample
@@ -164,6 +164,8 @@
           "timestamp": "2008-05-15T03:53:00-07:00"
         }
       ],
+      "acqUnitIds": [
+      ],
       "tags" : {
          "tagList" : [
            "important"

--- a/mod-orgs/examples/organization_get.sample
+++ b/mod-orgs/examples/organization_get.sample
@@ -165,6 +165,10 @@
       "timestamp": "2008-05-15T03:53:00-07:00"
     }
   ],
+  "acqUnitIds": [
+    "1895e539-8dac-441e-b1f5-aab62b3fde60",
+    "47f504bd-0c1b-498e-a2ae-e2f0a0cea273"
+  ],
   "tags" : {
      "tagList" : [
        "important"

--- a/mod-orgs/examples/organization_post.sample
+++ b/mod-orgs/examples/organization_post.sample
@@ -165,6 +165,9 @@
       "important"
     ]
   },
+  "acqUnitIds": [
+    "1895e539-8dac-441e-b1f5-aab62b3fde60"
+  ],
   "changelogs": [
     {
       "description": "This is a sample note.",

--- a/mod-orgs/examples/organization_put.sample
+++ b/mod-orgs/examples/organization_put.sample
@@ -157,6 +157,10 @@
       "notes": ""
     }
   ],
+  "acqUnitIds": [
+    "1895e539-8dac-441e-b1f5-aab62b3fde60",
+    "47f504bd-0c1b-498e-a2ae-e2f0a0cea273"
+  ],
   "tags" : {
      "tagList" : [
         "important"

--- a/mod-orgs/schemas/organization.json
+++ b/mod-orgs/schemas/organization.json
@@ -5,8 +5,7 @@
   "properties": {
     "id": {
       "description": "The unique UUID for this organization",
-      "type": ["string", "null"],
-      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+      "$ref": "../../common/schemas/uuid.json"
     },
     "name": {
       "description": "The name of this organization",
@@ -84,8 +83,7 @@
       "type": "array",
       "items": {
         "description": "UUID of a contact record",
-        "type": "string",
-        "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        "$ref": "../../common/schemas/uuid.json"
       }
     },
     "agreements": {
@@ -364,8 +362,7 @@
       "type": "array",
       "items": {
         "description": "UUID of an interface record",
-        "type": "string",
-        "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        "$ref": "../../common/schemas/uuid.json"
       }
     },
     "accounts": {
@@ -393,6 +390,13 @@
       "items": {
         "type": "object",
         "$ref": "changelog.json"
+      }
+    },
+    "acqUnitIds": {
+      "description": "acquisition unit ids associated with this organization",
+      "type": "array",
+      "items": {
+        "$ref": "../../common/schemas/uuid.json"
       }
     },
     "tags": {


### PR DESCRIPTION
## Purpose
[MODORGS-43](https://issues.folio.org/browse/MODORGS-43) support ability to assign acq units to organization account records

## Approach
- acqUnitIds added to organization schema
- sample updated

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Examples exist for all schemas
  - [ ] Descriptions exist for all schema properties
  - [ ] All schemas pass raml-cop linting
- Does this introduce breaking changes?
  - [ ] Were there any schema changes?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
