### PR TITLE
MODFIN-76 - CompositeFund schema

### DIFF
--- a/mod-finance/examples/composite_fund.sample
+++ b/mod-finance/examples/composite_fund.sample
@@ -1,0 +1,33 @@
+{
+  "id": "6e2fbba3-d557-4480-bca3-b6f5c645de04",
+  "allocatedFromIds": [
+    "1a490199-833d-4876-b2ff-2bd61f8324f1",
+    "d69a001c-ac69-4348-bee1-f9f3ef8a3f32"
+  ],
+  "allocatedToIds": [
+    "c08a5b0c-6717-4788-9df5-b0e8338c1172"
+  ],
+  "code": "HIST",
+  "description": "Tracking fund for the History department",
+  "externalAccountNo": "1121112569489",
+  "fundStatus": "Active",
+  "fundTypeId": "c93373df-e7ec-4d31-b200-719736610d89",
+  "ledgerId": "7ebd02c8-2bd4-40ae-b44d-0e76dc197633",
+  "name": "History",
+  "acqUnitIds": [
+    "1895e539-8dac-441e-b1f5-aab62b3fde60",
+    "47f504bd-0c1b-498e-a2ae-e2f0a0cea273"
+  ],
+  "groupIds": [
+    "f33ed99b-852a-4f90-9891-5efe0feab165"
+  ],
+  "tags": {
+    "tagList": [
+      "tag"
+    ]
+  },
+  "metadata": {
+    "createdDate": "2020-07-19T10:00:00.000+0000",
+    "createdByUserId": "28d1057c-d137-11e8-a8d5-f2801f1b9fd1"
+  }
+}

--- a/mod-finance/examples/composite_fund.sample
+++ b/mod-finance/examples/composite_fund.sample
@@ -1,33 +1,35 @@
 {
-  "id": "6e2fbba3-d557-4480-bca3-b6f5c645de04",
-  "allocatedFromIds": [
-    "1a490199-833d-4876-b2ff-2bd61f8324f1",
-    "d69a001c-ac69-4348-bee1-f9f3ef8a3f32"
-  ],
-  "allocatedToIds": [
-    "c08a5b0c-6717-4788-9df5-b0e8338c1172"
-  ],
-  "code": "HIST",
-  "description": "Tracking fund for the History department",
-  "externalAccountNo": "1121112569489",
-  "fundStatus": "Active",
-  "fundTypeId": "c93373df-e7ec-4d31-b200-719736610d89",
-  "ledgerId": "7ebd02c8-2bd4-40ae-b44d-0e76dc197633",
-  "name": "History",
-  "acqUnitIds": [
-    "1895e539-8dac-441e-b1f5-aab62b3fde60",
-    "47f504bd-0c1b-498e-a2ae-e2f0a0cea273"
-  ],
+  "fund": {
+    "id": "6e2fbba3-d557-4480-bca3-b6f5c645de04",
+    "allocatedFromIds": [
+      "1a490199-833d-4876-b2ff-2bd61f8324f1",
+      "d69a001c-ac69-4348-bee1-f9f3ef8a3f32"
+    ],
+    "allocatedToIds": [
+      "c08a5b0c-6717-4788-9df5-b0e8338c1172"
+    ],
+    "code": "HIST",
+    "description": "Tracking fund for the History department",
+    "externalAccountNo": "1121112569489",
+    "fundStatus": "Active",
+    "fundTypeId": "c93373df-e7ec-4d31-b200-719736610d89",
+    "ledgerId": "7ebd02c8-2bd4-40ae-b44d-0e76dc197633",
+    "name": "History",
+    "acqUnitIds": [
+      "1895e539-8dac-441e-b1f5-aab62b3fde60",
+      "47f504bd-0c1b-498e-a2ae-e2f0a0cea273"
+    ],
+    "tags": {
+      "tagList": [
+        "tag"
+      ]
+    },
+    "metadata": {
+      "createdDate": "2020-07-19T10:00:00.000+0000",
+      "createdByUserId": "28d1057c-d137-11e8-a8d5-f2801f1b9fd1"
+    }
+  },
   "groupIds": [
     "f33ed99b-852a-4f90-9891-5efe0feab165"
-  ],
-  "tags": {
-    "tagList": [
-      "tag"
-    ]
-  },
-  "metadata": {
-    "createdDate": "2020-07-19T10:00:00.000+0000",
-    "createdByUserId": "28d1057c-d137-11e8-a8d5-f2801f1b9fd1"
-  }
+  ]
 }

--- a/mod-finance/schemas/composite_fund.json
+++ b/mod-finance/schemas/composite_fund.json
@@ -1,0 +1,92 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "A composite fund to track financial transactions",
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "UUID of this composite fund",
+      "$ref": "../../common/schemas/uuid.json"
+    },
+    "allocatedFromIds": {
+      "description": "All the funds that this composite fund is allowed to receive money from. This would be 1 composite fund or none. If this field is blank their is no restriction on allocating to this composite fund",
+      "type": "array",
+      "items": {
+        "description": "UUID of the composite fund this composite fund is allowed to receive money from",
+        "$ref": "../../common/schemas/uuid.json"
+      }
+    },
+    "allocatedToIds": {
+      "description": "All the funds that this composite fund is allowed to send money to. This could be one or many.",
+      "type": "array",
+      "items": {
+        "description": "UUID of the composite fund this composite fund is allowed to send money to",
+        "$ref": "../../common/schemas/uuid.json"
+      }
+    },
+    "code": {
+      "description": "A unique code associated with the composite fund",
+      "type": "string"
+    },
+    "description": {
+      "description": "The description of this composite fund",
+      "type": "string"
+    },
+    "externalAccountNo": {
+      "description": "Corresponding account in the financial system. Will be recorded in payment generated as well.",
+      "type": "string"
+    },
+    "fundStatus": {
+      "description": "The current status of this composite fund",
+      "type": "string",
+      "enum": [
+        "Active",
+        "Frozen",
+        "Inactive"
+      ]
+    },
+    "fundTypeId": {
+      "description": "UUID of the composite fund type associated with this composite fund",
+      "$ref": "../../common/schemas/uuid.json"
+    },
+    "ledgerId": {
+      "description": "UUID of the financial ledger associated with this composite fund",
+      "$ref": "../../common/schemas/uuid.json"
+    },
+    "name": {
+      "description": "The name of this composite fund",
+      "type": "string"
+    },
+    "acqUnitIds": {
+      "description": "acquisition unit ids associated with this composite fund",
+      "type": "array",
+      "items": {
+        "$ref": "../../common/schemas/uuid.json"
+      }
+    },
+    "groupIds": {
+      "description": "group ids associated with this composite fund",
+      "type": "array",
+      "items": {
+        "$ref": "../../common/schemas/uuid.json"
+      }
+    },
+    "tags": {
+      "type" : "object",
+      "description": "arbitrary tags associated with this composite fund",
+      "$ref" : "../../../raml-util/schemas/tags.schema"
+    },
+    "metadata": {
+      "description": "Metadata about creation and changes to record, provided by the server (client should not provide)",
+      "type": "object",
+      "$ref": "../../../raml-util/schemas/metadata.schema",
+      "readonly": true
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "code",
+    "fundStatus",
+    "ledgerId",
+    "name"
+  ]
+}

--- a/mod-finance/schemas/composite_fund.json
+++ b/mod-finance/schemas/composite_fund.json
@@ -3,90 +3,16 @@
   "description": "A composite fund to track financial transactions",
   "type": "object",
   "properties": {
-    "id": {
-      "description": "UUID of this composite fund",
-      "$ref": "../../common/schemas/uuid.json"
-    },
-    "allocatedFromIds": {
-      "description": "All the funds that this composite fund is allowed to receive money from. This would be 1 composite fund or none. If this field is blank their is no restriction on allocating to this composite fund",
-      "type": "array",
-      "items": {
-        "description": "UUID of the composite fund this composite fund is allowed to receive money from",
-        "$ref": "../../common/schemas/uuid.json"
-      }
-    },
-    "allocatedToIds": {
-      "description": "All the funds that this composite fund is allowed to send money to. This could be one or many.",
-      "type": "array",
-      "items": {
-        "description": "UUID of the composite fund this composite fund is allowed to send money to",
-        "$ref": "../../common/schemas/uuid.json"
-      }
-    },
-    "code": {
-      "description": "A unique code associated with the composite fund",
-      "type": "string"
-    },
-    "description": {
-      "description": "The description of this composite fund",
-      "type": "string"
-    },
-    "externalAccountNo": {
-      "description": "Corresponding account in the financial system. Will be recorded in payment generated as well.",
-      "type": "string"
-    },
-    "fundStatus": {
-      "description": "The current status of this composite fund",
-      "type": "string",
-      "enum": [
-        "Active",
-        "Frozen",
-        "Inactive"
-      ]
-    },
-    "fundTypeId": {
-      "description": "UUID of the composite fund type associated with this composite fund",
-      "$ref": "../../common/schemas/uuid.json"
-    },
-    "ledgerId": {
-      "description": "UUID of the financial ledger associated with this composite fund",
-      "$ref": "../../common/schemas/uuid.json"
-    },
-    "name": {
-      "description": "The name of this composite fund",
-      "type": "string"
-    },
-    "acqUnitIds": {
-      "description": "acquisition unit ids associated with this composite fund",
-      "type": "array",
-      "items": {
-        "$ref": "../../common/schemas/uuid.json"
-      }
+    "fund": {
+      "type": "object",
+      "$ref": "fund.json"
     },
     "groupIds": {
-      "description": "group ids associated with this composite fund",
+      "description": "Group ids associated with this fund",
       "type": "array",
       "items": {
         "$ref": "../../common/schemas/uuid.json"
       }
-    },
-    "tags": {
-      "type" : "object",
-      "description": "arbitrary tags associated with this composite fund",
-      "$ref" : "../../../raml-util/schemas/tags.schema"
-    },
-    "metadata": {
-      "description": "Metadata about creation and changes to record, provided by the server (client should not provide)",
-      "type": "object",
-      "$ref": "../../../raml-util/schemas/metadata.schema",
-      "readonly": true
     }
-  },
-  "additionalProperties": false,
-  "required": [
-    "code",
-    "fundStatus",
-    "ledgerId",
-    "name"
-  ]
+  }
 }

--- a/mod-finance/schemas/composite_fund.json
+++ b/mod-finance/schemas/composite_fund.json
@@ -4,6 +4,7 @@
   "type": "object",
   "properties": {
     "fund": {
+      "description": "Fund to track financial transactions",
       "type": "object",
       "$ref": "fund.json"
     },


### PR DESCRIPTION
[MODFIN-76](https://issues.folio.org/browse/MODFIN-76) - CompositeFund schema

## Purpose
In order to keep the UI logic simple, we're introducing a new schema used between the business logic module and the UI: composite_fund with groupIds array<string> field.

## Approach
composite_fund.json schema added,
example added.

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Examples exist for all schemas
  - [x] Descriptions exist for all schema properties
  - [x] All schemas pass raml-cop linting
- Does this introduce breaking changes?
  - [ ] Were there any schema changes?
  - [x] There are no breaking changes in this PR.