### PR TITLE
MODORDER-315: Default to "In process" for item status during receiving/check-in

### DIFF
--- a/mod-orders/examples/checkinCollection.sample
+++ b/mod-orders/examples/checkinCollection.sample
@@ -19,7 +19,7 @@
           "accessionNumber": "1956.1",
           "itemDescription": "This is the piece item one to checkin",
           "electronicBookplate": "This book is from the Harvard University library",
-          "itemStatus": "Received"
+          "itemStatus": "In process"
         },
         {
           "id": "71d9322b-5cdd-45d8-ad45-c7f3044802e7",

--- a/mod-orders/examples/receivingCollection.sample
+++ b/mod-orders/examples/receivingCollection.sample
@@ -18,7 +18,7 @@
           "callNumber": "BF2050 .M335 1999",
           "comment": "Very important note",
           "caption": "Vol. 2",
-          "itemStatus": "Received",
+          "itemStatus": "In process",
           "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
           "pieceId": "cb9b0468-f2b4-4a13-b64c-662c4c9ec3ed"
         }

--- a/mod-orders/schemas/checkinCollection.json
+++ b/mod-orders/schemas/checkinCollection.json
@@ -87,15 +87,11 @@
                   "type": "string"
                 },
                 "itemStatus": {
-                  "default": "In process",
                   "description": "The status of the Check in piece",
                   "type": "string"
                 }
               },
-              "additionalProperties": false,
-              "required": [
-                "itemStatus"
-              ]
+              "additionalProperties": false
             }
           }
         },

--- a/mod-orders/schemas/checkinCollection.json
+++ b/mod-orders/schemas/checkinCollection.json
@@ -87,6 +87,7 @@
                   "type": "string"
                 },
                 "itemStatus": {
+                  "default": "In process",
                   "description": "The status of the Check in piece",
                   "type": "string"
                 }

--- a/mod-orders/schemas/checkinCollection.json
+++ b/mod-orders/schemas/checkinCollection.json
@@ -88,7 +88,8 @@
                 },
                 "itemStatus": {
                   "description": "The status of the Check in piece",
-                  "type": "string"
+                  "type": "string",
+                  "default": "In process"
                 }
               },
               "additionalProperties": false

--- a/mod-orders/schemas/receivingCollection.json
+++ b/mod-orders/schemas/receivingCollection.json
@@ -43,7 +43,6 @@
                   "type": "string"
                 },
                 "itemStatus": {
-                  "default": "In process",
                   "description": "The status of the item",
                   "type": "string"
                 },
@@ -59,7 +58,6 @@
                 }
               },
               "required": [
-                "itemStatus",
                 "pieceId"
               ],
               "additionalProperties": false

--- a/mod-orders/schemas/receivingCollection.json
+++ b/mod-orders/schemas/receivingCollection.json
@@ -44,7 +44,8 @@
                 },
                 "itemStatus": {
                   "description": "The status of the item",
-                  "type": "string"
+                  "type": "string",
+                  "default": "In process"
                 },
                 "locationId": {
                   "description": "The id of the location",

--- a/mod-orders/schemas/receivingCollection.json
+++ b/mod-orders/schemas/receivingCollection.json
@@ -43,6 +43,7 @@
                   "type": "string"
                 },
                 "itemStatus": {
+                  "default": "In process",
                   "description": "The status of the item",
                   "type": "string"
                 },


### PR DESCRIPTION

<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders 
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://issues.folio.org/browse/MODORDERS-315

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- Update checkinCollection and receivingCollection schema to make `itemStatus` optional
- Need to make it optional so when `itemStatus` is empty, it will default to "In process" during 
 receiving/checkin

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
