### PR TITLE
MODORGS-53 - Organization code optional in back-end, required in front-end

### DIFF
--- a/mod-orgs/schemas/organization.json
+++ b/mod-orgs/schemas/organization.json
@@ -407,6 +407,7 @@
   "additionalProperties": false,
   "required": [
     "name",
-    "status"
+    "status",
+    "code"
   ]
 }


### PR DESCRIPTION
[MODORGS-53](https://issues.folio.org/browse/MODORGS-53) - Organization code optional in back-end, required in front-end

## Purpose
In the front-end the organization code is required, but non-required in back-end.

## Approach
Organization schema changing - code becomes required.

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Examples exist for all schemas
  - [x] Descriptions exist for all schema properties
  - [x] All schemas pass raml-cop linting
- Does this introduce breaking changes?
  - [x] Were there any schema changes?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
