### PR TITLE
MODORDERS-353 - Migrate to new major version of item-storage, inventory, circulation

### DIFF
--- a/mod-orders/examples/checkinCollection.sample
+++ b/mod-orders/examples/checkinCollection.sample
@@ -36,7 +36,7 @@
           "accessionNumber": "2002.4",
           "itemDescription": "This is the piece item two to checkin",
           "electronicBookplate": "This book is from the Florida University library",
-          "itemStatus":"Received"
+          "itemStatus":"In process"
         }
       ]
     }

--- a/mod-orders/examples/receivingCollection.sample
+++ b/mod-orders/examples/receivingCollection.sample
@@ -9,7 +9,7 @@
           "callNumber": "PR 8923 W6 L36 1990 c.3",
           "comment": "Very important note",
           "caption": "Vol. 1",
-          "itemStatus": "Received",
+          "itemStatus": "In process",
           "locationId": "eb2d063a-5b4c-4cab-8db1-5fc5c5941df6",
           "pieceId": "c18c49b7-d970-44d6-b5d4-bd76c1c62d83"
         },

--- a/mod-orders/schemas/checkinCollection.json
+++ b/mod-orders/schemas/checkinCollection.json
@@ -50,11 +50,11 @@
                 "createItem": {
                   "description": "Whether or not to create an item record for this piece",
                   "type": "boolean"
-                },   
+                },
                 "supplement": {
                   "description": "Whether or not this is a supplementary material for this piece",
                   "type": "boolean"
-                }, 
+                },
                 "locationId": {
                   "description": "The id of the location",
                   "type": "string",
@@ -88,7 +88,7 @@
                 },
                 "itemStatus": {
                   "description": "The status of the Check in piece",
-                  "type": "string",
+                  "$ref": "item_status.json",
                   "default": "In process"
                 }
               },

--- a/mod-orders/schemas/item_status.json
+++ b/mod-orders/schemas/item_status.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "The status of the Item",
+  "type": "string",
+  "enum": [
+    "In process",
+    "On order",
+    "Available",
+    "In transit",
+    "Undefined"
+  ]
+}

--- a/mod-orders/schemas/receivingCollection.json
+++ b/mod-orders/schemas/receivingCollection.json
@@ -44,7 +44,7 @@
                 },
                 "itemStatus": {
                   "description": "The status of the item",
-                  "type": "string",
+                  "$ref": "item_status.json",
                   "default": "In process"
                 },
                 "locationId": {


### PR DESCRIPTION
[MODORDERS-353](https://issues.folio.org/browse/MODORDERS-353) - Migrate to new major version of item-storage, inventory, circulation

## Purpose
Making of enumeration of orders-specific item statuses in the schema.

## Approach
Item statuses enumeration of order-specific statuses.


## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Examples exist for all schemas
  - [x] Descriptions exist for all schema properties
  - [x] All schemas pass raml-cop linting
- Does this introduce breaking changes?
  - [ ] Were there any schema changes?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
