### PR TITLE
MODINVOSTO-52 - Distinct id/exportConfigId fields

### DIFF
--- a/mod-invoice-storage/examples/credentials.sample
+++ b/mod-invoice-storage/examples/credentials.sample
@@ -1,5 +1,6 @@
 {
-  "id": "e91d44e4-ae4f-401a-b355-3ea44f57a628",
+  "id": "574f0791-beca-4470-8037-050660cfb73a",
+  "exportConfigId": "e91d44e4-ae4f-401a-b355-3ea44f57a628",
   "username": "jsmith",
   "password": "letmein",
   "metadata": {

--- a/mod-invoice-storage/schemas/credentials.json
+++ b/mod-invoice-storage/schemas/credentials.json
@@ -4,7 +4,7 @@
   "type": "object",
   "properties": {
     "id": {
-      "description": "UUID of the credentials record, the same as the voucher export configuration UUID",
+      "description": "UUID of this credentials record",
       "$ref": "../../common/schemas/uuid.json"
     },
     "username": {
@@ -15,6 +15,10 @@
       "description": "The password portion of these credentials",
       "type": "string"
     },
+    "exportConfigid": {
+      "description": "UUID of the batch voucher export configuration record these credentials as associated with",
+      "$ref": "../../common/schemas/uuid.json"
+    },
     "metadata": {
       "type": "object",
       "$ref": "../../../raml-util/schemas/metadata.schema",
@@ -23,7 +27,7 @@
   },
   "additionalProperties": false,
   "required": [
-    "id",
+    "exportConfigId",
     "username"
   ]
 }

--- a/mod-invoice-storage/schemas/credentials.json
+++ b/mod-invoice-storage/schemas/credentials.json
@@ -15,7 +15,7 @@
       "description": "The password portion of these credentials",
       "type": "string"
     },
-    "exportConfigid": {
+    "exportConfigId": {
       "description": "UUID of the batch voucher export configuration record these credentials as associated with",
       "$ref": "../../common/schemas/uuid.json"
     },


### PR DESCRIPTION
## Purpose
I've decided to go a slightly different route than what's on the wiki page wrt batch voucher export configuration credentials in that these records should have their own `id` as well as an explicit reference to the export configuration they're associated with (`exportConfigId`).  This is consistent with how we manage interface credentials in organizations-storage.  I also discussed this with the tech leads and the preference is to have distinct ids in these situations.

## Approach
* Add `exportConfigId` and make required
* Make `id` optional and fix it's description
* Update schema example

#### TODOS and Open Questions
- [ ] Merge before https://github.com/folio-org/mod-invoice-storage/pull/60

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Examples exist for all schemas
  - [x] Descriptions exist for all schema properties
  - [x] All schemas pass raml-cop linting
- Does this introduce breaking changes?
  - [ ] Were there any schema changes?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
