### PR TITLE
MODORGSTOR-67 - Add an "acqUnitIds" field to the organization schema

### DIFF
--- a/mod-orgs/examples/organization_collection.sample
+++ b/mod-orgs/examples/organization_collection.sample
@@ -49,9 +49,9 @@
         {
           "value": "noreply@folio.org",
           "description": "Main",
-          "categories": [	
-            "112ae2e4-88ae-4fa5-a75b-2379d2035e52",	
-            "56288fe8-8037-44da-8395-01d2d106dc54"	
+          "categories": [
+            "112ae2e4-88ae-4fa5-a75b-2379d2035e52",
+            "56288fe8-8037-44da-8395-01d2d106dc54"
           ],
           "language": "en-us"
         }
@@ -61,9 +61,9 @@
           "value": "http://folio.org",
           "description": "",
           "language": "en-us",
-          "categories": [	
-            "112ae2e4-88ae-4fa5-a75b-2379d2035e52",	
-            "56288fe8-8037-44da-8395-01d2d106dc54"	
+          "categories": [
+            "112ae2e4-88ae-4fa5-a75b-2379d2035e52",
+            "56288fe8-8037-44da-8395-01d2d106dc54"
           ],
           "notes": "note"
         }
@@ -163,6 +163,10 @@
           "description": "This is a sample note.",
           "timestamp": "2008-05-15T03:53:00-07:00"
         }
+      ],
+      "acqUnitIds": [
+        "1895e539-8dac-441e-b1f5-aab62b3fde60",
+        "47f504bd-0c1b-498e-a2ae-e2f0a0cea273"
       ],
       "tags" : {
          "tagList" : [

--- a/mod-orgs/examples/organization_collection.sample
+++ b/mod-orgs/examples/organization_collection.sample
@@ -155,7 +155,11 @@
           "contactInfo": "Some basic contact information note.",
           "libraryCode": "My Library",
           "libraryEdiCode": "MY-LIB-1",
-          "notes": "note"
+          "notes": "note",
+           "acqUnitIds": [
+             "1895e539-8dac-441e-b1f5-aab62b3fde60",
+             "47f504bd-0c1b-498e-a2ae-e2f0a0cea273"
+           ]
         }
       ],
       "changelogs": [

--- a/mod-orgs/examples/organization_get.sample
+++ b/mod-orgs/examples/organization_get.sample
@@ -165,6 +165,10 @@
       "timestamp": "2008-05-15T03:53:00-07:00"
     }
   ],
+  "acqUnitIds": [
+    "1895e539-8dac-441e-b1f5-aab62b3fde60",
+    "47f504bd-0c1b-498e-a2ae-e2f0a0cea273"
+  ],
   "tags" : {
      "tagList" : [
        "important"

--- a/mod-orgs/examples/organization_get.sample
+++ b/mod-orgs/examples/organization_get.sample
@@ -156,7 +156,11 @@
       "contactInfo": "Some basic contact information note.",
       "libraryCode": "My Library",
       "libraryEdiCode": "MY-LIB-1",
-      "notes": "note"
+      "notes": "note",
+      "acqUnitIds": [
+        "1895e539-8dac-441e-b1f5-aab62b3fde60",
+        "47f504bd-0c1b-498e-a2ae-e2f0a0cea273"
+      ]
     }
   ],
   "changelogs": [

--- a/mod-orgs/examples/organization_post.sample
+++ b/mod-orgs/examples/organization_post.sample
@@ -158,6 +158,10 @@
       "notes": "note"
     }
   ],
+  "acqUnitIds": [
+    "1895e539-8dac-441e-b1f5-aab62b3fde60",
+    "47f504bd-0c1b-498e-a2ae-e2f0a0cea273"
+  ],
   "tags" : {
     "tagList" : [
       "important"

--- a/mod-orgs/examples/organization_post.sample
+++ b/mod-orgs/examples/organization_post.sample
@@ -155,7 +155,11 @@
       "contactInfo": "Some basic contact information note.",
       "libraryCode": "My Library",
       "libraryEdiCode": "MY-LIB-1",
-      "notes": "note"
+      "notes": "note",
+      "acqUnitIds": [
+        "1895e539-8dac-441e-b1f5-aab62b3fde60",
+        "47f504bd-0c1b-498e-a2ae-e2f0a0cea273"
+      ]
     }
   ],
   "acqUnitIds": [

--- a/mod-orgs/examples/organization_put.sample
+++ b/mod-orgs/examples/organization_put.sample
@@ -154,7 +154,11 @@
       "contactInfo": "Some basic contact information note.",
       "libraryCode": "My Library",
       "libraryEdiCode": "MY-LIB-1",
-      "notes": ""
+      "notes": "",
+      "acqUnitIds": [
+        "1895e539-8dac-441e-b1f5-aab62b3fde60",
+        "47f504bd-0c1b-498e-a2ae-e2f0a0cea273"
+      ]
     }
   ],
   "acqUnitIds": [

--- a/mod-orgs/examples/organization_put.sample
+++ b/mod-orgs/examples/organization_put.sample
@@ -157,6 +157,10 @@
       "notes": ""
     }
   ],
+  "acqUnitIds": [
+    "1895e539-8dac-441e-b1f5-aab62b3fde60",
+    "47f504bd-0c1b-498e-a2ae-e2f0a0cea273"
+  ],
   "tags" : {
      "tagList" : [
         "important"

--- a/mod-orgs/schemas/account.json
+++ b/mod-orgs/schemas/account.json
@@ -52,6 +52,13 @@
     "notes": {
       "description": "The notes for this account",
       "type": "string"
+    },
+    "acqUnitIds": {
+      "description": "Acquisition unit UUIDs associated with this organizations account",
+      "type": "array",
+      "items": {
+        "$ref": "../../common/schemas/uuid.json"
+      }
     }
   },
   "additionalProperties": false,

--- a/mod-orgs/schemas/organization.json
+++ b/mod-orgs/schemas/organization.json
@@ -394,6 +394,13 @@
         "$ref": "changelog.json"
       }
     },
+    "acqUnitIds": {
+      "description": "Acquisition unit UUIDs associated with this organization",
+      "type": "array",
+      "items": {
+        "$ref": "../../common/schemas/uuid.json"
+      }
+    },
     "tags": {
       "type": "object",
       "description": "arbitrary tags associated with this organization",


### PR DESCRIPTION
[MODORGSTOR-67](https://issues.folio.org/browse/MODORGSTOR-67) - Add an "acqUnitIds" field to the organization schema

## Purpose
To enable support of acquisition units for organizations management

## Approach
Adding non-mandatory array of acq unit IDs in the organization schema
## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Examples exist for all schemas
  - [ ] Descriptions exist for all schema properties
  - [ ] All schemas pass raml-cop linting
- Does this introduce breaking changes?
  - [ ] Were there any schema changes?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
