### PR TITLE
[MODORDSTOR-135] Add titleId field to the piece schema and create a foreign key

### DIFF
--- a/mod-orders-storage/examples/piece_collection.sample
+++ b/mod-orders-storage/examples/piece_collection.sample
@@ -9,6 +9,7 @@
         "itemId": "522a501a-56b5-48d9-b28a-3a8f02482d97",
         "locationId": "53cf956f-c1df-410b-8bea-27f712cca7c0",
         "poLineId": "d471d766-8dbb-4609-999a-02681dea6c22",
+        "titleId": "9a665b22-9fe5-4c95-b4ee-837a5433c95d",
         "receiptDate": "2020-01-10T00:00:00.000Z",
         "receivingStatus": "Expected",
         "supplement": true
@@ -21,6 +22,7 @@
         "itemId": "fefa55b1-a4b3-4f2f-b7a0-39efd7cab54c",
         "locationId": "26241f60-5b96-4c10-9873-dcf4343691db",
         "poLineId": "3622bc51-d579-48e4-a1c7-1bcdea42be97",
+        "titleId": "9a665b22-9fe5-4c95-b4ee-837a5433c95d",
         "receiptDate": "2018-10-11T00:00:00.000Z",
         "receivingStatus": "Received",
         "supplement": true,
@@ -32,6 +34,7 @@
         "comment": "Deluxe Edition",
         "format": "Other",
         "poLineId": "d471d766-8dbb-4609-999a-02681dea6c22",
+        "titleId": "9a665b22-9fe5-4c95-b4ee-837a5433c95d",
         "receivingStatus": "Received",
         "supplement": true,
         "receiptDate": "2018-10-11T00:00:00.000Z",

--- a/mod-orders-storage/examples/piece_get.sample
+++ b/mod-orders-storage/examples/piece_get.sample
@@ -6,6 +6,7 @@
   "itemId": "522a501a-56b5-48d9-b28a-3a8f02482d97",
   "locationId": "53cf956f-c1df-410b-8bea-27f712cca7c0",
   "poLineId": "d471d766-8dbb-4609-999a-02681dea6c22",
+  "titleId": "9a665b22-9fe5-4c95-b4ee-837a5433c95d",
   "receivingStatus": "Expected",
   "supplement": true,
   "receiptDate": "2018-10-11T00:00:00.000Z"

--- a/mod-orders-storage/examples/piece_post.sample
+++ b/mod-orders-storage/examples/piece_post.sample
@@ -5,6 +5,7 @@
   "itemId": "522a501a-56b5-48d9-b28a-3a8f02482d97",
   "locationId": "53cf956f-c1df-410b-8bea-27f712cca7c0",
   "poLineId": "d471d766-8dbb-4609-999a-02681dea6c22",
+  "titleId": "9a665b22-9fe5-4c95-b4ee-837a5433c95d",
   "receivingStatus": "Expected",
   "supplement": true,
   "receiptDate": "2018-10-11T00:00:00.000Z"

--- a/mod-orders-storage/schemas/piece.json
+++ b/mod-orders-storage/schemas/piece.json
@@ -64,6 +64,7 @@
   "required": [
     "format",
     "poLineId",
+    "titleId",
     "receivingStatus"
   ]
 }

--- a/mod-orders-storage/schemas/piece.json
+++ b/mod-orders-storage/schemas/piece.json
@@ -32,6 +32,10 @@
       "description": "UUID of the purchase order line this record is associated with",
       "$ref": "../../common/schemas/uuid.json"
     },
+    "titleId": {
+      "description": "UUID of the title record",
+      "$ref": "../../common/schemas/uuid.json"
+    },
      "receivingStatus": {
       "description": "the status of this piece",
       "type": "string",


### PR DESCRIPTION
## Purpose
[MODORDSTOR-135](https://issues.folio.org/browse/MODORDSTOR-135)
In order to support filtering titles by information in the associated piece record, we need to add a titleId field to the piece schema and create a foreign key.

## Approach
- Add titleId into the pieces

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Examples exist for all schemas
  - [ ] Descriptions exist for all schema properties
  - [ ] All schemas pass raml-cop linting
- Does this introduce breaking changes?
  - [ ] Were there any schema changes?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
