### PR TITLE
MODORDERS-389 Unable to remove prefixes/suffixes that are currently used by an existing orders

### DIFF
--- a/common/schemas/entity.json
+++ b/common/schemas/entity.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Purchase order number prefix",
+  "type": "object",
+  "javaName": "entity",
+  "properties": {
+    "id": {
+      "description": "UUID identifying this entity",
+      "$ref": "../../common/schemas/uuid.json"
+    }
+  },
+  "additionalProperties": false
+}

--- a/mod-orders-storage/schemas/prefix.json
+++ b/mod-orders-storage/schemas/prefix.json
@@ -2,11 +2,10 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "Purchase order number prefix",
   "type": "object",
+  "extends" : {
+    "$ref" : "../../common/schemas/entity.json"
+  },
   "properties": {
-    "id": {
-      "description": "UUID identifying this prefix",
-      "$ref": "../../common/schemas/uuid.json"
-    },
     "name": {
       "description": "Prefix name",
       "type": "string"

--- a/mod-orders-storage/schemas/purchase_order.json
+++ b/mod-orders-storage/schemas/purchase_order.json
@@ -2,12 +2,10 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "purchase order",
   "type": "object",
+  "extends" : {
+    "$ref" : "../../common/schemas/entity.json"
+  },
   "properties": {
-    "id": {
-      "description": "UUID of this purchase order",
-      "type": "string",
-      "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
-    },
     "approved": {
       "description": "whether or not the purchase order has been approved",
       "type": "boolean",

--- a/mod-orders-storage/schemas/reason_for_closure.json
+++ b/mod-orders-storage/schemas/reason_for_closure.json
@@ -3,11 +3,10 @@
   "description": "Reason for closure object",
   "type": "object",
   "javaType" : "org.folio.rest.jaxrs.model.ReasonForClosure",
+  "extends" : {
+    "$ref" : "../../common/schemas/entity.json"
+  },
   "properties": {
-    "id": {
-      "description": "UUID identifying this reason for closure",
-      "$ref": "../../common/schemas/uuid.json"
-    },
     "reason": {
       "description": "Reason for closure",
       "type": "string"

--- a/mod-orders-storage/schemas/suffix.json
+++ b/mod-orders-storage/schemas/suffix.json
@@ -2,11 +2,10 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "Purchase order number suffix",
   "type": "object",
+  "extends" : {
+    "$ref" : "../../common/schemas/entity.json"
+  },
   "properties": {
-    "id": {
-      "description": "UUID identifying this suffix",
-      "$ref": "../../common/schemas/uuid.json"
-    },
     "name": {
       "description": "Suffix name",
       "type": "string"


### PR DESCRIPTION
## Purpose
[MODORDERS-389](https://issues.folio.org/browse/MODORDERS-389) to have a basic class for models in order to simplify the development of generic functionality.

## Approach
- adding base entity.json schema for records with id
- config, purchase_order schemas extend entity.json

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Examples exist for all schemas
  - [ ] Descriptions exist for all schema properties
  - [ ] All schemas pass raml-cop linting
- Does this introduce breaking changes?
  - [ ] Were there any schema changes?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
