### PR TITLE
MODORDSTOR-147 - Add resourceUrl field to the eresource schema

### DIFF
--- a/mod-orders-storage/examples/po_line_collection.sample
+++ b/mod-orders-storage/examples/po_line_collection.sample
@@ -64,7 +64,7 @@
           "materialType": "f7e72403-2a13-43a4-a069-aaabe6c9dea8",
           "trial": false,
           "userLimit": 10,
-          "resourceUrl": "http://sample.com/document.pdf"
+          "resourceUrl": "https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf"
         },
         "fundDistribution": [
           {

--- a/mod-orders-storage/examples/po_line_collection.sample
+++ b/mod-orders-storage/examples/po_line_collection.sample
@@ -63,7 +63,8 @@
           },
           "materialType": "f7e72403-2a13-43a4-a069-aaabe6c9dea8",
           "trial": false,
-          "userLimit": 10
+          "userLimit": 10,
+          "resourceUrl": "http://sample.com/document.pdf"
         },
         "fundDistribution": [
           {

--- a/mod-orders-storage/examples/po_line_get.sample
+++ b/mod-orders-storage/examples/po_line_get.sample
@@ -64,7 +64,7 @@
     "materialType": "4920caaf-871f-4f08-9bd5-b897203fd7fb",
     "trial": false,
     "userLimit": 10,
-    "resourceUrl": "http://sample.com/document.pdf"
+    "resourceUrl": "https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf"
   },
   "fundDistribution": [
     {

--- a/mod-orders-storage/examples/po_line_get.sample
+++ b/mod-orders-storage/examples/po_line_get.sample
@@ -63,7 +63,8 @@
     },
     "materialType": "4920caaf-871f-4f08-9bd5-b897203fd7fb",
     "trial": false,
-    "userLimit": 10
+    "userLimit": 10,
+    "resourceUrl": "http://sample.com/document.pdf"
   },
   "fundDistribution": [
     {

--- a/mod-orders-storage/schemas/eresource.json
+++ b/mod-orders-storage/schemas/eresource.json
@@ -50,6 +50,11 @@
       "description": "UUID of the material Type",
       "type": "string",
       "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+    },
+    "resourceUrl": {
+      "description": "Electronic resource can be access via this URL",
+      "type": "string",
+      "pattern": "\\b((?:[a-z][\\w-]+:(?:\/{1,3}|[a-z0-9%])|www\\d{0,3}[.]|[a-z0-9.\\-]+[.][a-z]{2,4}\/)(?:[^\\s()<>]+|\\(([^\\s()<>]+|(\\([^\\s()<>]+\\)))*\\))+(?:\\(([^\\s()<>]+|(\\([^\\s()<>]+\\)))*\\)|[^\\s`!()\\[\\]{};:'\".,<>?]))"
     }
   },
   "additionalProperties": false


### PR DESCRIPTION
[MODORDSTOR-147](https://issues.folio.org/browse/MODORDSTOR-147) - Add resourceUrl field to the eresource schema

## Purpose
In order to support UIOR-556, we need to update the eresource.json schema.

## Approach
* Added optional "resourceUrl" field to the ramls/acq-models/mod-orders-storage/schemas/eresource.json.
* Updated samples

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Examples exist for all schemas
  - [ ] Descriptions exist for all schema properties
  - [ ] All schemas pass raml-cop linting
- Does this introduce breaking changes?
  - [ ] Were there any schema changes?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
