### PR TITLE
[MODFISTO-244] Restrict code syntax, expense class code required

### DIFF
--- a/mod-finance/schemas/expense_class.json
+++ b/mod-finance/schemas/expense_class.json
@@ -13,7 +13,8 @@
     },
     "code": {
       "description": "The code of the expense class",
-      "type": "string"
+      "type": "string",
+      "pattern": "^[^:]+$"
     },
     "externalAccountNumberExt": {
       "description": "An external account number extension",
@@ -31,6 +32,7 @@
   },
   "additionalProperties": false,
   "required": [
-    "name"
+    "name",
+    "code"
   ]
 }

--- a/mod-finance/schemas/fund.json
+++ b/mod-finance/schemas/fund.json
@@ -25,7 +25,8 @@
     },
     "code": {
       "description": "A unique code associated with the fund",
-      "type": "string"
+      "type": "string",
+      "pattern": "^[^:]+$"
     },
     "description": {
       "description": "The description of this fund",


### PR DESCRIPTION
## Purpose
[MODFISTO-244](https://issues.folio.org/browse/MODFISTO-244) - Add validation for special character to Fund Code and Expense class code and prepare migration script

## Approach
- Fund codes and expense class codes can no longer use the character ":" (colon)
- Expense class code is now a required field

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Examples exist for all schemas
  - [ ] Descriptions exist for all schema properties
  - [ ] All schemas pass raml-cop linting
- Does this introduce breaking changes?
  - [ ] Were there any schema changes?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
