### PR TITLE
MODFISTO-267 - add orderId/invoiceId to transaction summaries

### DIFF
--- a/mod-finance/examples/invoice_transaction_summary.sample
+++ b/mod-finance/examples/invoice_transaction_summary.sample
@@ -1,5 +1,6 @@
 {
   "id": "ff5bf77f-8e30-459b-bc98-ddcbd764e3f0",
+  "invoiceId": "3e4661d8-4549-4906-9928-4a249cf7412e",
   "numPendingPayments": -10,
   "numPaymentsCredits": 10
 }

--- a/mod-finance/examples/order_transaction_summary.sample
+++ b/mod-finance/examples/order_transaction_summary.sample
@@ -1,4 +1,5 @@
 {
   "id": "f2715f25-8504-4698-afd0-3025aa779ac6",
+  "orderId": "81971200-62c8-4d37-a7f9-d62a6b88a521",
   "numTransactions": 1
 }

--- a/mod-finance/schemas/invoice_transaction_summary.json
+++ b/mod-finance/schemas/invoice_transaction_summary.json
@@ -7,6 +7,10 @@
       "description": "UUID of this summary",
       "$ref": "../../common/schemas/uuid.json"
     },
+    "invoiceId": {
+      "description": "UUID of the invoice for which the summary is created",
+      "$ref": "../../common/schemas/uuid.json"
+    },
     "numPendingPayments": {
       "description": "Total number of pending payments(transactions) expected for this invoice. Negative value indicates that all transactions have been processed",
       "type": "integer"
@@ -19,6 +23,7 @@
   "additionalProperties": false,
   "required": [
     "id",
+    "invoiceId",
     "numPendingPayments",
     "numPaymentsCredits"
   ]

--- a/mod-finance/schemas/order_transaction_summary.json
+++ b/mod-finance/schemas/order_transaction_summary.json
@@ -7,6 +7,10 @@
       "description": "UUID of this summary",
       "$ref": "../../common/schemas/uuid.json"
     },
+    "orderId": {
+      "description": "UUID of purchase order for which the summary is created",
+      "$ref": "../../common/schemas/uuid.json"
+    },
     "numTransactions": {
       "description": "Total number of transactions (encumbrances) expected for this order. Negative value indicates that all transactions have been processed",
       "type": "integer"
@@ -15,6 +19,7 @@
   "additionalProperties": false,
   "required": [
     "id",
+    "orderId",
     "numTransactions"
   ]
 }


### PR DESCRIPTION
## Purpose
Separate summary ID from order/invoice ID to avoid collision.

## Approach
Added orderId field to order_transaction_summary and invoiceId field to invoice_transaction_summary.

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Examples exist for all schemas
  - [ ] Descriptions exist for all schema properties
  - [ ] All schemas pass raml-cop linting
- Does this introduce breaking changes?
  - [ ] Were there any schema changes?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
