### PR TITLE
[MODORDSTOR-277] - Add field "lastEDIExportDate" into POL to support filtering on UI side

### DIFF
--- a/mod-orders-storage/examples/po_line_get.sample
+++ b/mod-orders-storage/examples/po_line_get.sample
@@ -98,6 +98,7 @@
       "quantityPhysical": 2
     }
   ],
+  "lastEDIExportDate": "2018-10-05T00:00:00.000Z",
   "orderFormat": "P/E Mix",
   "paymentStatus": "Awaiting Payment",
   "physical": {

--- a/mod-orders-storage/schemas/po_line.json
+++ b/mod-orders-storage/schemas/po_line.json
@@ -125,7 +125,8 @@
     },
     "lastEDIExportDate": {
       "description": "The last date when line was exported in the EDIFACT file",
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "orderFormat": {
       "description": "The purchase order line format",

--- a/mod-orders-storage/schemas/po_line.json
+++ b/mod-orders-storage/schemas/po_line.json
@@ -123,6 +123,10 @@
         "$ref": "location.json"
       }
     },
+    "lastEDIExportDate": {
+      "description": "The last date when line was exported in the EDIFACT file",
+      "type": "string"
+    },
     "orderFormat": {
       "description": "The purchase order line format",
       "type": "object",


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/MODORDSTOR-277

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Examples exist for all schemas
  - [x] Descriptions exist for all schema properties
  - [x] All schemas pass raml-cop linting
- Does this introduce breaking changes?
  - [ ] Were there any schema changes?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
