### PR TITLE
[MODFISTO-303] Added a _version field to some finance schemas

### DIFF
--- a/mod-finance/schemas/budget.json
+++ b/mod-finance/schemas/budget.json
@@ -11,6 +11,10 @@
       "description": "UUID of this budget",
       "$ref": "../../common/schemas/uuid.json"
     },
+    "_version": {
+      "type": "integer",
+      "description": "Record version for optimistic locking"
+    },
     "name": {
       "description": "The name of the budget",
       "type": "string"

--- a/mod-finance/schemas/budget_expense_class.json
+++ b/mod-finance/schemas/budget_expense_class.json
@@ -11,6 +11,10 @@
       "type": "string",
       "$ref": "../../common/schemas/uuid.json"
     },
+    "_version": {
+      "type": "integer",
+      "description": "Record version for optimistic locking"
+    },
     "budgetId": {
       "description": "UUID of the budget record",
       "$ref": "../../common/schemas/uuid.json"

--- a/mod-finance/schemas/expense_class.json
+++ b/mod-finance/schemas/expense_class.json
@@ -11,6 +11,10 @@
       "type": "string",
       "$ref": "../../common/schemas/uuid.json"
     },
+    "_version": {
+      "type": "integer",
+      "description": "Record version for optimistic locking"
+    },
     "code": {
       "description": "The code of the expense class",
       "type": "string",

--- a/mod-finance/schemas/fiscal_year.json
+++ b/mod-finance/schemas/fiscal_year.json
@@ -7,6 +7,10 @@
       "description": "UUID of the fiscal year record",
       "$ref": "../../common/schemas/uuid.json"
     },
+    "_version": {
+      "type": "integer",
+      "description": "Record version for optimistic locking"
+    },
     "acqUnitIds": {
       "description": "UUIDs of the acquisition units associated with this fiscal year",
       "type": "array",

--- a/mod-finance/schemas/fund.json
+++ b/mod-finance/schemas/fund.json
@@ -7,6 +7,10 @@
       "description": "UUID of this fund",
       "$ref": "../../common/schemas/uuid.json"
     },
+    "_version": {
+      "type": "integer",
+      "description": "Record version for optimistic locking"
+    },
     "allocatedFromIds": {
       "description": "All the funds that this fund is allowed to receive money from. This would be 1 fund or none. If this field is blank their is no restriction on allocating to this fund",
       "type": "array",

--- a/mod-finance/schemas/fund_type.json
+++ b/mod-finance/schemas/fund_type.json
@@ -7,6 +7,10 @@
       "description": "UUID of fund type",
       "$ref": "../../common/schemas/uuid.json"
     },
+    "_version": {
+      "type": "integer",
+      "description": "Record version for optimistic locking"
+    },
     "name": {
       "description": "Name of fund type",
       "type": "string"

--- a/mod-finance/schemas/group.json
+++ b/mod-finance/schemas/group.json
@@ -7,6 +7,10 @@
       "description": "UUID of the group record",
       "$ref": "../../common/schemas/uuid.json"
     },
+    "_version": {
+      "type": "integer",
+      "description": "Record version for optimistic locking"
+    },
     "acqUnitIds": {
       "description": "UUIDs of the acquisition units associated with this group",
       "type": "array",

--- a/mod-finance/schemas/group_fund_fiscal_year.json
+++ b/mod-finance/schemas/group_fund_fiscal_year.json
@@ -7,6 +7,10 @@
       "description": "UUID of the record",
       "$ref": "../../common/schemas/uuid.json"
     },
+    "_version": {
+      "type": "integer",
+      "description": "Record version for optimistic locking"
+    },
     "budgetId": {
       "description": "UUID of the budget record",
       "$ref": "../../common/schemas/uuid.json"

--- a/mod-finance/schemas/ledger.json
+++ b/mod-finance/schemas/ledger.json
@@ -7,6 +7,10 @@
       "description": "UUID of this ledger",
       "$ref": "../../common/schemas/uuid.json"
     },
+    "_version": {
+      "type": "integer",
+      "description": "Record version for optimistic locking"
+    },
     "name": {
       "description": "The name of the ledger",
       "type": "string"

--- a/mod-finance/schemas/ledger_fiscal_year_rollover.json
+++ b/mod-finance/schemas/ledger_fiscal_year_rollover.json
@@ -7,6 +7,10 @@
       "description": "id of ledger fiscal year rollover",
       "$ref": "../../common/schemas/uuid.json"
     },
+    "_version": {
+      "type": "integer",
+      "description": "Record version for optimistic locking"
+    },
     "ledgerId": {
       "description": "Ledger UUID for which rollover was started",
       "$ref": "../../common/schemas/uuid.json"

--- a/mod-finance/schemas/shared_budget.json
+++ b/mod-finance/schemas/shared_budget.json
@@ -7,6 +7,10 @@
       "description": "UUID of this budget",
       "$ref": "../../common/schemas/uuid.json"
     },
+    "_version": {
+      "type": "integer",
+      "description": "Record version for optimistic locking"
+    },
     "name": {
       "description": "The name of the budget",
       "type": "string"

--- a/mod-finance/schemas/transaction.json
+++ b/mod-finance/schemas/transaction.json
@@ -10,6 +10,10 @@
       "$ref": "../../common/schemas/uuid.json",
       "description": "UUID of this transaction"
     },
+    "_version": {
+      "type": "integer",
+      "description": "Record version for optimistic locking"
+    },
     "amount": {
       "description": "The amount of this transaction. For encumbrances: This is initialAmountEncumbered - (amountAwaitingPayment + amountExpended)",
       "type": "number"


### PR DESCRIPTION
## Purpose
[MODFISTO-303](https://issues.folio.org/browse/MODFISTO-303) - Enable optimistic locking (for finance)

## Approach
Added a _version attribute to the relevant schemas.

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Examples exist for all schemas
  - [ ] Descriptions exist for all schema properties
  - [ ] All schemas pass raml-cop linting
- Does this introduce breaking changes?
  - [ ] Were there any schema changes?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
