### PR TITLE
[MODFISTO-319] Added missed optimistic locking field

### DIFF
--- a/mod-finance/schemas/ledger_fiscal_year_rollover_budget.json
+++ b/mod-finance/schemas/ledger_fiscal_year_rollover_budget.json
@@ -7,6 +7,10 @@
       "description": "UUID of this budget",
       "$ref": "../../common/schemas/uuid.json"
     },
+    "_version": {
+      "type": "integer",
+      "description": "Record version for optimistic locking"
+    },
     "ledgerRolloverId": {
       "description": "Ledger fiscal year rollover UUID",
       "$ref": "../../common/schemas/uuid.json"


### PR DESCRIPTION
## Purpose
In recently schema changes was added field with name "withOptimisticLocking" to new table "ledger_fiscal_year_rollover_budget":
![image](https://user-images.githubusercontent.com/89521577/183119544-121fd212-159a-4dcf-ad48-aeaa705e734a.png)
We should add _version field for successfully serialization/deserialization pojo

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Examples exist for all schemas
  - [ ] Descriptions exist for all schema properties
  - [ ] All schemas pass raml-cop linting
- Does this introduce breaking changes?
  - [ ] Were there any schema changes?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
