### PR TITLE
[UIREC-249]. Item statuses are set to something other than "Order closed" or "On order"

### DIFF
--- a/mod-orders/schemas/item_status.json
+++ b/mod-orders/schemas/item_status.json
@@ -7,8 +7,23 @@
     "On order",
     "Available",
     "In transit",
-    "Undefined",
-    "Order closed"
+    "Order closed",
+    "Aged to lost",
+    "Awaiting pickup",
+    "Awaiting delivery",
+    "Checked out",
+    "Claimed returned",
+    "Declared lost",
+    "In process (non-requestable)",
+    "Intellectual item",
+    "Long missing",
+    "Lost and paid",
+    "Missing",
+    "Paged",
+    "Restricted",
+    "Unavailable",
+    "Unknown",
+    "Withdrawn"
   ],
   "default": "In process"
 }


### PR DESCRIPTION
https://issues.folio.org/browse/UIREC-249

Corresponding statuses from mod-inventory: https://github.com/folio-org/mod-inventory/blob/master/src/main/java/org/folio/inventory/domain/items/ItemStatusName.java