### PR TITLE
[MODORDERS-494] New order field: nextPolNumber

### DIFF
--- a/mod-orders-storage/examples/purchase_order_get.sample
+++ b/mod-orders-storage/examples/purchase_order_get.sample
@@ -43,6 +43,7 @@
     "1895e539-8dac-441e-b1f5-aab62b3fde60",
     "47f504bd-0c1b-498e-a2ae-e2f0a0cea273"
   ],
+  "nextPolNumber": 1,
   "metadata": {
     "createdDate": "2018-08-19T00:00:00.000+0000",
     "createdByUserId": "28d1057c-d137-11e8-a8d5-f2801f1b9fd1"

--- a/mod-orders-storage/schemas/purchase_order.json
+++ b/mod-orders-storage/schemas/purchase_order.json
@@ -116,6 +116,11 @@
         "$ref": "../../common/schemas/uuid.json"
       }
     },
+    "nextPolNumber": {
+      "description": "Number that will be used next time a purchase order line is created",
+      "type": "integer",
+      "readonly": true
+    },
     "tags": {
       "type": "object",
       "description": "arbitrary tags associated with this purchase order",

--- a/mod-orders/examples/composite_purchase_order.sample
+++ b/mod-orders/examples/composite_purchase_order.sample
@@ -35,6 +35,7 @@
   "totalExpended": 5.47,
   "vendor": "168f8a86-d26c-406e-813f-c7527f241ac3",
   "workflowStatus": "Open",
+  "nextPolNumber": 4,
   "metadata": {
     "createdDate": "2018-07-19T00:00:00.000+0000",
     "createdByUserId": "28d1057c-d137-11e8-a8d5-f2801f1b9fd1"

--- a/mod-orders/schemas/composite_purchase_order.json
+++ b/mod-orders/schemas/composite_purchase_order.json
@@ -141,6 +141,11 @@
         "$ref": "../../common/schemas/uuid.json"
       }
     },
+    "nextPolNumber": {
+      "description": "Number that will be used next time a purchase order line is created",
+      "type": "integer",
+      "readonly": true
+    },
     "tags": {
       "type": "object",
       "description": "arbitrary tags associated with this purchase order",


### PR DESCRIPTION
## Purpose
[MODORDERS-494](https://issues.folio.org/browse/MODORDERS-494) - Unexpected jump in POL number on 2 line PO

## Approach
Added a new field to orders and composite orders: `nextPolNumber`.

#### TODOS and Open Questions
This is needed for a future PR in mod-orders-storage. Also mod-orders and mod-invoice will need updated models.

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Examples exist for all schemas
  - [ ] Descriptions exist for all schema properties
  - [ ] All schemas pass raml-cop linting
- Does this introduce breaking changes?
  - [ ] Were there any schema changes?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
