### PR TITLE
MODINVOICE-455. Update models schema with new fields for ftp configuration

### DIFF
--- a/mod-invoice-storage/examples/export_configuration.sample
+++ b/mod-invoice-storage/examples/export_configuration.sample
@@ -5,7 +5,10 @@
   "weekdays": [ "Monday", "Wednesday" ],
   "enableScheduledExport": true,
   "format": "Application/xml",
-  "uploadURI": "ftp://ftp.amherst-lib.edu/invoices/",
+  "uploadURI": "ftp.amherst-lib.edu",
+  "uploadDirectory": "/files/invoices",
+  "ftpFormat": "SFTP",
+  "ftpPort": 22,
   "metadata": {
     "createdDate": "2020-01-28T00:12:04.000+0000",
     "createdByUserId": "28d1057c-d137-11e8-a8d5-f2801f1b9fd1"

--- a/mod-invoice-storage/schemas/export_configuration.json
+++ b/mod-invoice-storage/schemas/export_configuration.json
@@ -32,9 +32,24 @@
       "default": "00:00"
     },
     "uploadURI": {
-      "description": "URI batch vouchers should be uploaded to.  Limited to FTP initially",
+      "description": "Host where batch vouchers should be uploaded to. Limited to FTP initially",
+      "type": "string"
+    },
+    "uploadDirectory": {
+      "description": "The upload directory",
+      "type": "string"
+    },
+    "ftpFormat": {
+      "description": "The FTP format",
       "type": "string",
-      "pattern": "^ftp://([\\.\\_\\-a-z0-9]+)(/([\\./\\-\\_\\.a-z0-9]?)+)?$"
+      "enum": [
+        "SFTP",
+        "FTP"
+      ]
+    },
+    "ftpPort": {
+      "description": "The ftp port",
+      "type": "integer"
     },
     "weekdays": {
       "description": "An array of weekdays (enum: Sunday, Monday, etc.) indicating which days to trigger exports on.  If empty, indicates daily exports",


### PR DESCRIPTION
## Purpose
We need to support sftp login.
Currently Settings UI to upload batch groupls looks like this:
![image](https://github.com/folio-org/acq-models/assets/25097693/9cad7cd2-0811-4858-a844-0927a0b004b7)
Correct SFTP URI string looks like this:
"sftp://" + username + ":" + password + "@" + remoteHost + "/" + remoteDir + "file.txt");
Because we already have username and password as separate fields and need to intoduce new field for chosing ftp/sfpt - so uploadURI should contain only host. For ftp port introduced new field to have the same user experience as for EDI export.
Also added uplodDirectory for future if user wants to save exports in different folder, default is: /files/invoices
