### PR TITLE
[MODORDERS-964] Add `customFields` to purchase order and purchase order line

### DIFF
--- a/mod-orders-storage/examples/po_line_collection.sample
+++ b/mod-orders-storage/examples/po_line_collection.sample
@@ -130,6 +130,9 @@
           ],
           "vendorAccount": "8910-25"
         },
+        "customFields": {
+          "externalOrderNumber": "ML58723"
+        },
         "metadata": {
           "createdDate": "2018-07-19T00:00:00.000+0000",
           "createdByUserId": "28d1057c-d137-11e8-a8d5-f2801f1b9fd1"

--- a/mod-orders-storage/examples/po_line_get.sample
+++ b/mod-orders-storage/examples/po_line_get.sample
@@ -151,6 +151,9 @@
     ],
     "vendorAccount": "8910-25"
   },
+  "customFields": {
+    "externalOrderNumber": "ML58723"
+  },
   "metadata": {
     "createdDate": "2018-07-19T00:00:00.000+0000",
     "createdByUserId": "28d1057c-d137-11e8-a8d5-f2801f1b9fd1"

--- a/mod-orders-storage/examples/purchase_order_collection.sample
+++ b/mod-orders-storage/examples/purchase_order_collection.sample
@@ -42,6 +42,9 @@
         "1895e539-8dac-441e-b1f5-aab62b3fde60",
         "47f504bd-0c1b-498e-a2ae-e2f0a0cea273"
       ],
+      "customFields": {
+        "membership": "opt_0"
+      },
       "metadata": {
         "createdDate": "2018-07-19T00:00:00.000+0000",
         "createdByUserId": "28d1057c-d137-11e8-a8d5-f2801f1b9fd1"

--- a/mod-orders-storage/examples/purchase_order_get.sample
+++ b/mod-orders-storage/examples/purchase_order_get.sample
@@ -44,6 +44,9 @@
     "47f504bd-0c1b-498e-a2ae-e2f0a0cea273"
   ],
   "nextPolNumber": 1,
+  "customFields": {
+    "membership": "opt_0"
+  },
   "metadata": {
     "createdDate": "2018-08-19T00:00:00.000+0000",
     "createdByUserId": "28d1057c-d137-11e8-a8d5-f2801f1b9fd1"

--- a/mod-orders-storage/schemas/po_line.json
+++ b/mod-orders-storage/schemas/po_line.json
@@ -245,6 +245,11 @@
       "type": "object",
       "$ref": "vendor_detail.json"
     },
+    "customFields" : {
+      "description": "Object that contains custom field",
+      "type": "object",
+      "additionalProperties": true
+    },
     "metadata": {
       "type": "object",
       "$ref": "../../../raml-util/schemas/metadata.schema",

--- a/mod-orders-storage/schemas/purchase_order.json
+++ b/mod-orders-storage/schemas/purchase_order.json
@@ -123,6 +123,11 @@
       "description": "arbitrary tags associated with this purchase order",
       "$ref": "../../../raml-util/schemas/tags.schema"
     },
+    "customFields" : {
+      "description": "Object that contains custom field",
+      "type": "object",
+      "additionalProperties": true
+    },
     "metadata": {
       "type": "object",
       "$ref": "../../../raml-util/schemas/metadata.schema",

--- a/mod-orders/examples/composite_po_line.sample
+++ b/mod-orders/examples/composite_po_line.sample
@@ -164,6 +164,9 @@
     ],
     "vendorAccount": "8910-10"
   },
+  "customFields": {
+    "externalOrderNumber": "ML58723"
+  },
   "metadata": {
     "createdDate": "2018-07-19T00:00:00.000+0000",
     "createdByUserId": "28d1057c-d137-11e8-a8d5-f2801f1b9fd1"

--- a/mod-orders/examples/composite_purchase_order.sample
+++ b/mod-orders/examples/composite_purchase_order.sample
@@ -36,6 +36,9 @@
   "vendor": "168f8a86-d26c-406e-813f-c7527f241ac3",
   "workflowStatus": "Open",
   "nextPolNumber": 4,
+  "customFields": {
+    "membership": "opt_0"
+  },
   "metadata": {
     "createdDate": "2018-07-19T00:00:00.000+0000",
     "createdByUserId": "28d1057c-d137-11e8-a8d5-f2801f1b9fd1"
@@ -192,6 +195,9 @@
         "tagList": [
           "important"
         ]
+      },
+      "customFields": {
+        "externalOrderNumber": "ML58723"
       },
       "metadata": {
         "createdDate": "2018-07-19T00:00:00.000+0000",

--- a/mod-orders/schemas/composite_po_line.json
+++ b/mod-orders/schemas/composite_po_line.json
@@ -248,6 +248,11 @@
       "type": "object",
       "$ref": "../../mod-orders-storage/schemas/vendor_detail.json"
     },
+    "customFields" : {
+      "description": "Object that contains custom field",
+      "type": "object",
+      "additionalProperties": true
+    },
     "metadata": {
       "type": "object",
       "$ref": "../../../raml-util/schemas/metadata.schema",

--- a/mod-orders/schemas/composite_purchase_order.json
+++ b/mod-orders/schemas/composite_purchase_order.json
@@ -151,6 +151,11 @@
       "description": "arbitrary tags associated with this purchase order",
       "$ref": "../../../raml-util/schemas/tags.schema"
     },
+    "customFields" : {
+      "description": "Object that contains custom field",
+      "type": "object",
+      "additionalProperties": true
+    },
     "metadata": {
       "type": "object",
       "$ref": "../../../raml-util/schemas/metadata.schema",


### PR DESCRIPTION
## Purpose
Integration of custom fields into orders modules. See [MODORDERS-964](https://issues.folio.org/browse/MODORDERS-964).

## Approach
Attribute `customFields` is added to schemas for purchase order and purchase order line in `mod-orders` and `mod-orders-storage`.

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Examples exist for all schemas
  - [x] Descriptions exist for all schema properties
  - [x] All schemas pass raml-cop linting
- Does this introduce breaking changes?
  - [x] Were there any schema changes?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
