### PR TITLE
[MODORDSTOR-364] Create routing_list table and API for it

### DIFF
--- a/mod-orders-storage/examples/routing_list_collection.sample
+++ b/mod-orders-storage/examples/routing_list_collection.sample
@@ -2,6 +2,7 @@
     "routingLists": [
       {
         "id": "c0d13648-347b-4ac9-8c2f-5bc47248b87e",
+        "_version": 1,
         "name": "List name",
         "notes": "Some note",
         "userIds": [

--- a/mod-orders-storage/examples/routing_list_collection.sample
+++ b/mod-orders-storage/examples/routing_list_collection.sample
@@ -1,0 +1,15 @@
+{
+    "routingLists": [
+      {
+        "id": "c0d13648-347b-4ac9-8c2f-5bc47248b87e",
+        "name": "List name",
+        "notes": "Some note",
+        "userIds": [
+          "d926d900-e27d-46d6-bba8-31e9d5c2cf44",
+          "077274ad-6b4f-4c28-9779-6d381e7a1ca1"
+        ],
+        "poLineId": "8343e5a0-fed8-11e8-8eb2-f2801f1b9fd1"
+      }
+    ],
+    "totalRecords": 1
+}

--- a/mod-orders-storage/examples/routing_list_get.sample
+++ b/mod-orders-storage/examples/routing_list_get.sample
@@ -1,5 +1,6 @@
 {
   "id": "c0d13648-347b-4ac9-8c2f-5bc47248b87e",
+  "_version": 1,
   "name": "List name",
   "notes": "Some note",
   "userIds": [

--- a/mod-orders-storage/examples/routing_list_get.sample
+++ b/mod-orders-storage/examples/routing_list_get.sample
@@ -1,0 +1,10 @@
+{
+  "id": "c0d13648-347b-4ac9-8c2f-5bc47248b87e",
+  "name": "List name",
+  "notes": "Some note",
+  "userIds": [
+    "d926d900-e27d-46d6-bba8-31e9d5c2cf44",
+    "077274ad-6b4f-4c28-9779-6d381e7a1ca1"
+  ],
+  "poLineId": "8343e5a0-fed8-11e8-8eb2-f2801f1b9fd1"
+}

--- a/mod-orders-storage/schemas/routing_list.json
+++ b/mod-orders-storage/schemas/routing_list.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "routing list",
+  "type": "object",
+  "javaName": "RoutingList",
+  "properties": {
+    "id": {
+      "description": "UUID identifying this routing list entity",
+      "$ref": "../../common/schemas/uuid.json"
+    },
+    "name": {
+      "description": "name of the list",
+      "type": "string"
+    },
+    "notes": {
+      "description": "notes associated with the routing list",
+      "type": "string"
+    },
+    "userIds": {
+      "description": "UUIDs of associated users",
+      "id": "userIds",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "$ref": "../../common/schemas/uuid.json"
+      }
+    },
+    "poLineId": {
+      "description": "UUIDs of the associated PO Line",
+      "$ref": "../../common/schemas/uuid.json"
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "name",
+    "userIds",
+    "poLineId"
+  ]
+}

--- a/mod-orders-storage/schemas/routing_list.json
+++ b/mod-orders-storage/schemas/routing_list.json
@@ -8,6 +8,10 @@
       "description": "UUID identifying this routing list entity",
       "$ref": "../../common/schemas/uuid.json"
     },
+    "_version": {
+      "type": "integer",
+      "description": "Record version for optimistic locking"
+    },
     "name": {
       "description": "name of the list",
       "type": "string"

--- a/mod-orders-storage/schemas/routing_list_collection.json
+++ b/mod-orders-storage/schemas/routing_list_collection.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "collection of routing list records",
+  "type": "object",
+  "javaName": "RoutingListCollection",
+  "properties": {
+    "routingLists": {
+      "description": "collection of routing list records",
+      "type": "array",
+      "id": "routingLists",
+      "items": {
+        "type": "object",
+        "$ref": "routing_list.json"
+      }
+    },
+    "totalRecords": {
+      "description": "The number of objects contained in this collection",
+      "type": "integer"
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "routingLists",
+    "totalRecords"
+  ]
+}


### PR DESCRIPTION
## Purpose
[MODORDSTOR-364: Create routing_list table and API for it](https://folio-org.atlassian.net/browse/MODORDSTOR-364)

## Approach
* Add a new migration to create table for routing lists
* Add to acq models: RoutingList, RoutingListCollection
* Add API for all CRUD operations
