### PR TITLE
[MODORDSTOR-364] Remove ID as required field from Routing Lists

### DIFF
--- a/mod-orders-storage/examples/routing_list_collection.sample
+++ b/mod-orders-storage/examples/routing_list_collection.sample
@@ -1,7 +1,6 @@
 {
     "routingLists": [
       {
-        "id": "c0d13648-347b-4ac9-8c2f-5bc47248b87e",
         "_version": 1,
         "name": "List name",
         "notes": "Some note",

--- a/mod-orders-storage/examples/routing_list_get.sample
+++ b/mod-orders-storage/examples/routing_list_get.sample
@@ -1,5 +1,4 @@
 {
-  "id": "c0d13648-347b-4ac9-8c2f-5bc47248b87e",
   "_version": 1,
   "name": "List name",
   "notes": "Some note",

--- a/mod-orders-storage/schemas/routing_list.json
+++ b/mod-orders-storage/schemas/routing_list.json
@@ -41,7 +41,6 @@
   },
   "additionalProperties": false,
   "required": [
-    "id",
     "name",
     "userIds",
     "poLineId"


### PR DESCRIPTION
## Purpose
[[MODORDSTOR-364] Create routing_list table and API for it](https://folio-org.atlassian.net/browse/MODORDSTOR-364)

## Approach
- Remove ID field as required
- Remove IDs from samples