### PR TITLE
[MODORGSTOR-171]. Create Data Structure/Api to store Organization Integration details instead of mod-configuration

### DIFF
--- a/mod-orgs/examples/integration_detail_collection.sample
+++ b/mod-orgs/examples/integration_detail_collection.sample
@@ -1,70 +1,70 @@
 {
-    "integrationDetails": [
-        {
-            "id": "6a01fc0b-d556-49f9-a2bf-394718a9a3d4",
-            "_version": 1,
-            "exportConfigId": "123e4567-e89b-12d3-a456-426614174003",
-            "vendorId": "d0fb5aa0-cdf1-11e8-a8d5-f2801f1b9fd1",
-            "configName": "Sample EDI Config 1",
-            "configDescription": "This is a sample EDI configuration for a vendor.",
-            "ediConfig": {
-                "accountNoList": [
-                    "123456",
-                    "789012"
-                ],
-                "defaultAcquisitionMethods": [
-                    "e89b-12d3-a456-426614174000",
-                    "e89b-12d3-a456-426614174001"
-                ],
-                "ediNamingConvention": "Sample Naming Convention",
-                "libEdiCode": "LIB123",
-                "libEdiType": "014/EAN",
-                "vendorEdiCode": "VEND456",
-                "vendorEdiType": "091/Vendor-assigned",
-                "notes": "These are sample notes for the EDI configuration.",
-                "sendAccountNumber": true,
-                "supportOrder": true,
-                "supportInvoice": false
-            },
-            "ediFtp": {
-                "ftpFormat": "SFTP",
-                "serverAddress": "ftp://ftp.example.com",
-                "username": "ftpUser",
-                "password": "ftpPassword",
-                "ftpMode": "Binary",
-                "ftpConnMode": "Passive",
-                "ftpPort": 21,
-                "orderDirectory": "/orders",
-                "invoiceDirectory": "/invoices",
-                "notes": "FTP configuration notes",
-                "isPrimaryTransmissionMethod": true
-            },
-            "ediSchedule": {
-                "enableScheduledExport": false,
-                "scheduleParameters": {
-                    "id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
-                    "scheduleFrequency": 1,
-                    "schedulePeriod": "DAY",
-                    "schedulingDate": "2024-11-18T08:29:02.958+00:00",
-                    "scheduleTime": "02:00",
-                    "scheduleDay": 1,
-                    "weekDays": [
-                        "MONDAY",
-                        "WEDNESDAY",
-                        "FRIDAY"
-                    ],
-                    "timeZone": "UTC"
-                },
-                "schedulingNotes": "Schedule notes for this EDI job"
-            },
-            "isDefaultConfig": true,
-            "metadata": {
-                "createdDate": "2024-11-18T10:30:53.788+00:00",
-                "createdByUserId": "3ab24dc6-155f-4c8f-86d3-ce2e92e804e6",
-                "updatedDate": "2024-11-18T10:30:53.788+00:00",
-                "updatedByUserId": "3ab24dc6-155f-4c8f-86d3-ce2e92e804e6"
-            }
-        }
-    ],
-    "totalRecords": 1
+  "integrationDetails": [
+    {
+      "id": "6a01fc0b-d556-49f9-a2bf-394718a9a3d4",
+      "_version": 1,
+      "exportConfigId": "123e4567-e89b-12d3-a456-426614174003",
+      "vendorId": "d0fb5aa0-cdf1-11e8-a8d5-f2801f1b9fd1",
+      "configName": "Sample EDI Config 1",
+      "configDescription": "This is a sample EDI configuration for a vendor.",
+      "ediConfig": {
+        "accountNoList": [
+          "123456",
+          "789012"
+        ],
+        "defaultAcquisitionMethods": [
+          "e89b-12d3-a456-426614174000",
+          "e89b-12d3-a456-426614174001"
+        ],
+        "ediNamingConvention": "Sample Naming Convention",
+        "libEdiCode": "LIB123",
+        "libEdiType": "014/EAN",
+        "vendorEdiCode": "VEND456",
+        "vendorEdiType": "091/Vendor-assigned",
+        "notes": "These are sample notes for the EDI configuration.",
+        "sendAccountNumber": true,
+        "supportOrder": true,
+        "supportInvoice": false
+      },
+      "ediFtp": {
+        "ftpFormat": "SFTP",
+        "serverAddress": "ftp://ftp.example.com",
+        "username": "ftpUser",
+        "password": "ftpPassword",
+        "ftpMode": "Binary",
+        "ftpConnMode": "Passive",
+        "ftpPort": 21,
+        "orderDirectory": "/orders",
+        "invoiceDirectory": "/invoices",
+        "notes": "FTP configuration notes",
+        "isPrimaryTransmissionMethod": true
+      },
+      "ediSchedule": {
+        "enableScheduledExport": false,
+        "scheduleParameters": {
+          "id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
+          "scheduleFrequency": 1,
+          "schedulePeriod": "DAY",
+          "schedulingDate": "2024-11-18T08:29:02.958+00:00",
+          "scheduleTime": "02:00",
+          "scheduleDay": 1,
+          "weekDays": [
+            "MONDAY",
+            "WEDNESDAY",
+            "FRIDAY"
+          ],
+          "timeZone": "UTC"
+        },
+        "schedulingNotes": "Schedule notes for this EDI job"
+      },
+      "isDefaultConfig": true,
+      "metadata": {
+        "createdDate": "2024-11-18T10:30:53.788+00:00",
+        "createdByUserId": "3ab24dc6-155f-4c8f-86d3-ce2e92e804e6",
+        "updatedDate": "2024-11-18T10:30:53.788+00:00",
+        "updatedByUserId": "3ab24dc6-155f-4c8f-86d3-ce2e92e804e6"
+      }
+    }
+  ],
+  "totalRecords": 1
 }

--- a/mod-orgs/examples/integration_detail_collection.sample
+++ b/mod-orgs/examples/integration_detail_collection.sample
@@ -1,0 +1,70 @@
+{
+    "integrationDetails": [
+        {
+            "id": "6a01fc0b-d556-49f9-a2bf-394718a9a3d4",
+            "_version": 1,
+            "exportConfigId": "123e4567-e89b-12d3-a456-426614174003",
+            "vendorId": "d0fb5aa0-cdf1-11e8-a8d5-f2801f1b9fd1",
+            "configName": "Sample EDI Config 1",
+            "configDescription": "This is a sample EDI configuration for a vendor.",
+            "ediConfig": {
+                "accountNoList": [
+                    "123456",
+                    "789012"
+                ],
+                "defaultAcquisitionMethods": [
+                    "e89b-12d3-a456-426614174000",
+                    "e89b-12d3-a456-426614174001"
+                ],
+                "ediNamingConvention": "Sample Naming Convention",
+                "libEdiCode": "LIB123",
+                "libEdiType": "014/EAN",
+                "vendorEdiCode": "VEND456",
+                "vendorEdiType": "091/Vendor-assigned",
+                "notes": "These are sample notes for the EDI configuration.",
+                "sendAccountNumber": true,
+                "supportOrder": true,
+                "supportInvoice": false
+            },
+            "ediFtp": {
+                "ftpFormat": "SFTP",
+                "serverAddress": "ftp://ftp.example.com",
+                "username": "ftpUser",
+                "password": "ftpPassword",
+                "ftpMode": "Binary",
+                "ftpConnMode": "Passive",
+                "ftpPort": 21,
+                "orderDirectory": "/orders",
+                "invoiceDirectory": "/invoices",
+                "notes": "FTP configuration notes",
+                "isPrimaryTransmissionMethod": true
+            },
+            "ediSchedule": {
+                "enableScheduledExport": false,
+                "scheduleParameters": {
+                    "id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
+                    "scheduleFrequency": 1,
+                    "schedulePeriod": "DAY",
+                    "schedulingDate": "2024-11-18T08:29:02.958+00:00",
+                    "scheduleTime": "02:00",
+                    "scheduleDay": 1,
+                    "weekDays": [
+                        "MONDAY",
+                        "WEDNESDAY",
+                        "FRIDAY"
+                    ],
+                    "timeZone": "UTC"
+                },
+                "schedulingNotes": "Schedule notes for this EDI job"
+            },
+            "isDefaultConfig": true,
+            "metadata": {
+                "createdDate": "2024-11-18T10:30:53.788+00:00",
+                "createdByUserId": "3ab24dc6-155f-4c8f-86d3-ce2e92e804e6",
+                "updatedDate": "2024-11-18T10:30:53.788+00:00",
+                "updatedByUserId": "3ab24dc6-155f-4c8f-86d3-ce2e92e804e6"
+            }
+        }
+    ],
+    "totalRecords": 1
+}

--- a/mod-orgs/examples/integration_detail_get.sample
+++ b/mod-orgs/examples/integration_detail_get.sample
@@ -1,0 +1,65 @@
+{
+    "id": "6a01fc0b-d556-49f9-a2bf-394718a9a3d4",
+    "_version": 1,
+    "exportConfigId": "123e4567-e89b-12d3-a456-426614174003",
+    "vendorId": "d0fb5aa0-cdf1-11e8-a8d5-f2801f1b9fd1",
+    "configName": "Sample EDI Config 1",
+    "configDescription": "This is a sample EDI configuration for a vendor.",
+    "ediConfig": {
+        "accountNoList": [
+            "123456",
+            "789012"
+        ],
+        "defaultAcquisitionMethods": [
+            "e89b-12d3-a456-426614174000",
+            "e89b-12d3-a456-426614174001"
+        ],
+        "ediNamingConvention": "Sample Naming Convention",
+        "libEdiCode": "LIB123",
+        "libEdiType": "014/EAN",
+        "vendorEdiCode": "VEND456",
+        "vendorEdiType": "091/Vendor-assigned",
+        "notes": "These are sample notes for the EDI configuration.",
+        "sendAccountNumber": true,
+        "supportOrder": true,
+        "supportInvoice": false
+    },
+    "ediFtp": {
+        "ftpFormat": "SFTP",
+        "serverAddress": "ftp://ftp.example.com",
+        "username": "ftpUser",
+        "password": "ftpPassword",
+        "ftpMode": "Binary",
+        "ftpConnMode": "Passive",
+        "ftpPort": 21,
+        "orderDirectory": "/orders",
+        "invoiceDirectory": "/invoices",
+        "notes": "FTP configuration notes",
+        "isPrimaryTransmissionMethod": true
+    },
+    "ediSchedule": {
+        "enableScheduledExport": false,
+        "scheduleParameters": {
+            "id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
+            "scheduleFrequency": 1,
+            "schedulePeriod": "DAY",
+            "schedulingDate": "2024-11-18T08:29:02.958+00:00",
+            "scheduleTime": "02:00",
+            "scheduleDay": 1,
+            "weekDays": [
+                "MONDAY",
+                "WEDNESDAY",
+                "FRIDAY"
+            ],
+            "timeZone": "UTC"
+        },
+        "schedulingNotes": "Schedule notes for this EDI job"
+    },
+    "isDefaultConfig": true,
+    "metadata": {
+        "createdDate": "2024-11-18T10:30:53.788+00:00",
+        "createdByUserId": "3ab24dc6-155f-4c8f-86d3-ce2e92e804e6",
+        "updatedDate": "2024-11-18T10:30:53.788+00:00",
+        "updatedByUserId": "3ab24dc6-155f-4c8f-86d3-ce2e92e804e6"
+    }
+}

--- a/mod-orgs/examples/integration_detail_get.sample
+++ b/mod-orgs/examples/integration_detail_get.sample
@@ -1,65 +1,65 @@
 {
-    "id": "6a01fc0b-d556-49f9-a2bf-394718a9a3d4",
-    "_version": 1,
-    "exportConfigId": "123e4567-e89b-12d3-a456-426614174003",
-    "vendorId": "d0fb5aa0-cdf1-11e8-a8d5-f2801f1b9fd1",
-    "configName": "Sample EDI Config 1",
-    "configDescription": "This is a sample EDI configuration for a vendor.",
-    "ediConfig": {
-        "accountNoList": [
-            "123456",
-            "789012"
-        ],
-        "defaultAcquisitionMethods": [
-            "e89b-12d3-a456-426614174000",
-            "e89b-12d3-a456-426614174001"
-        ],
-        "ediNamingConvention": "Sample Naming Convention",
-        "libEdiCode": "LIB123",
-        "libEdiType": "014/EAN",
-        "vendorEdiCode": "VEND456",
-        "vendorEdiType": "091/Vendor-assigned",
-        "notes": "These are sample notes for the EDI configuration.",
-        "sendAccountNumber": true,
-        "supportOrder": true,
-        "supportInvoice": false
+  "id": "6a01fc0b-d556-49f9-a2bf-394718a9a3d4",
+  "_version": 1,
+  "exportConfigId": "123e4567-e89b-12d3-a456-426614174003",
+  "vendorId": "d0fb5aa0-cdf1-11e8-a8d5-f2801f1b9fd1",
+  "configName": "Sample EDI Config 1",
+  "configDescription": "This is a sample EDI configuration for a vendor.",
+  "ediConfig": {
+    "accountNoList": [
+      "123456",
+      "789012"
+    ],
+    "defaultAcquisitionMethods": [
+      "e89b-12d3-a456-426614174000",
+      "e89b-12d3-a456-426614174001"
+    ],
+    "ediNamingConvention": "Sample Naming Convention",
+    "libEdiCode": "LIB123",
+    "libEdiType": "014/EAN",
+    "vendorEdiCode": "VEND456",
+    "vendorEdiType": "091/Vendor-assigned",
+    "notes": "These are sample notes for the EDI configuration.",
+    "sendAccountNumber": true,
+    "supportOrder": true,
+    "supportInvoice": false
+  },
+  "ediFtp": {
+    "ftpFormat": "SFTP",
+    "serverAddress": "ftp://ftp.example.com",
+    "username": "ftpUser",
+    "password": "ftpPassword",
+    "ftpMode": "Binary",
+    "ftpConnMode": "Passive",
+    "ftpPort": 21,
+    "orderDirectory": "/orders",
+    "invoiceDirectory": "/invoices",
+    "notes": "FTP configuration notes",
+    "isPrimaryTransmissionMethod": true
+  },
+  "ediSchedule": {
+    "enableScheduledExport": false,
+    "scheduleParameters": {
+      "id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
+      "scheduleFrequency": 1,
+      "schedulePeriod": "DAY",
+      "schedulingDate": "2024-11-18T08:29:02.958+00:00",
+      "scheduleTime": "02:00",
+      "scheduleDay": 1,
+      "weekDays": [
+        "MONDAY",
+        "WEDNESDAY",
+        "FRIDAY"
+      ],
+      "timeZone": "UTC"
     },
-    "ediFtp": {
-        "ftpFormat": "SFTP",
-        "serverAddress": "ftp://ftp.example.com",
-        "username": "ftpUser",
-        "password": "ftpPassword",
-        "ftpMode": "Binary",
-        "ftpConnMode": "Passive",
-        "ftpPort": 21,
-        "orderDirectory": "/orders",
-        "invoiceDirectory": "/invoices",
-        "notes": "FTP configuration notes",
-        "isPrimaryTransmissionMethod": true
-    },
-    "ediSchedule": {
-        "enableScheduledExport": false,
-        "scheduleParameters": {
-            "id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
-            "scheduleFrequency": 1,
-            "schedulePeriod": "DAY",
-            "schedulingDate": "2024-11-18T08:29:02.958+00:00",
-            "scheduleTime": "02:00",
-            "scheduleDay": 1,
-            "weekDays": [
-                "MONDAY",
-                "WEDNESDAY",
-                "FRIDAY"
-            ],
-            "timeZone": "UTC"
-        },
-        "schedulingNotes": "Schedule notes for this EDI job"
-    },
-    "isDefaultConfig": true,
-    "metadata": {
-        "createdDate": "2024-11-18T10:30:53.788+00:00",
-        "createdByUserId": "3ab24dc6-155f-4c8f-86d3-ce2e92e804e6",
-        "updatedDate": "2024-11-18T10:30:53.788+00:00",
-        "updatedByUserId": "3ab24dc6-155f-4c8f-86d3-ce2e92e804e6"
-    }
+    "schedulingNotes": "Schedule notes for this EDI job"
+  },
+  "isDefaultConfig": true,
+  "metadata": {
+    "createdDate": "2024-11-18T10:30:53.788+00:00",
+    "createdByUserId": "3ab24dc6-155f-4c8f-86d3-ce2e92e804e6",
+    "updatedDate": "2024-11-18T10:30:53.788+00:00",
+    "updatedByUserId": "3ab24dc6-155f-4c8f-86d3-ce2e92e804e6"
+  }
 }

--- a/mod-orgs/examples/integration_detail_post.sample
+++ b/mod-orgs/examples/integration_detail_post.sample
@@ -1,0 +1,48 @@
+{
+  "_version": 1,
+  "exportConfigId": "123e4567-e89b-12d3-a456-426614174003",
+  "vendorId": "d0fb5aa0-cdf1-11e8-a8d5-f2801f1b9fd1",
+  "configName": "Sample EDI Config 1",
+  "configDescription": "This is a sample EDI configuration for a vendor.",
+  "ediConfig": {
+    "accountNoList": ["123456", "789012"],
+    "defaultAcquisitionMethods": ["e89b-12d3-a456-426614174000", "e89b-12d3-a456-426614174001"],
+    "ediNamingConvention": "Sample Naming Convention",
+    "libEdiCode": "LIB123",
+    "libEdiType": "014/EAN",
+    "vendorEdiCode": "VEND456",
+    "vendorEdiType": "091/Vendor-assigned",
+    "notes": "These are sample notes for the EDI configuration.",
+    "sendAccountNumber": true,
+    "supportOrder": true,
+    "supportInvoice": false
+  },
+  "ediFtp": {
+    "ftpConnMode": "Passive",
+    "ftpFormat": "SFTP",
+    "ftpMode": "Binary",
+    "ftpPort": 21,
+    "invoiceDirectory": "/invoices",
+    "isPrimaryTransmissionMethod": true,
+    "notes": "FTP configuration notes",
+    "orderDirectory": "/orders",
+    "password": "ftpPassword",
+    "serverAddress": "ftp://ftp.example.com",
+    "username": "ftpUser"
+  },
+  "ediSchedule": {
+    "enableScheduledExport": false,
+    "scheduleParameters": {
+      "id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
+      "scheduleFrequency": 1,
+      "schedulePeriod": "DAY",
+      "schedulingDate": "2024-11-18T08:29:02.958+00:00",
+      "scheduleTime": "02:00",
+      "scheduleDay": 1,
+      "weekDays": ["MONDAY", "WEDNESDAY", "FRIDAY"],
+      "timeZone": "UTC"
+    },
+    "schedulingNotes": "Schedule notes for this EDI job"
+  },
+  "isDefaultConfig": true
+}

--- a/mod-orgs/schemas/edi_config.json
+++ b/mod-orgs/schemas/edi_config.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "EDI config",
+  "type": "object",
+  "properties": {
+    "accountNoList": {
+      "description": "The list of account numbers of the vendor",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "defaultAcquisitionMethods": {
+      "description": "Default acquisition methods for the accounts",
+      "type": "array",
+      "items": {
+        "description": "UUID of the acquisition method",
+        "$ref": "../../common/schemas/uuid.json"
+      }
+    },
+    "ediNamingConvention": {
+      "description": "The naming convention for this EDI",
+      "type": "string"
+    },
+    "libEdiCode": {
+      "description": "The library code for this EDI",
+      "type": "string"
+    },
+    "libEdiType": {
+      "description": "The library type for this EDI",
+      "type": "string",
+      "enum": [
+        "014/EAN",
+        "31B/US-SAN",
+        "091/Vendor-assigned",
+        "092/Customer-assigned"
+      ]
+    },
+    "vendorEdiCode": {
+      "description": "The library code for this EDI",
+      "type": "string"
+    },
+    "vendorEdiType": {
+      "description": "The library type for this EDI",
+      "type": "string",
+      "enum": [
+        "014/EAN",
+        "31B/US-SAN",
+        "091/Vendor-assigned",
+        "092/Customer-assigned"
+      ]
+    },
+    "notes": {
+      "description": "The notes for this EDI",
+      "type": "string"
+    },
+    "sendAccountNumber": {
+      "description": "If true then send account number",
+      "type": "boolean",
+      "default": false
+    },
+    "supportOrder": {
+      "description": "If true then order support",
+      "type": "boolean",
+      "default": false
+    },
+    "supportInvoice": {
+      "description": "If true then invoice support",
+      "type": "boolean",
+      "default": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/mod-orgs/schemas/edi_ftp.json
+++ b/mod-orgs/schemas/edi_ftp.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "The FTP object for this EDI",
+  "type": "object",
+  "properties": {
+    "ftpConnMode": {
+      "description": "The FTP connection mode for this EDI",
+      "type": "string",
+      "enum": [
+        "Active",
+        "Passive"
+      ]
+    },
+    "ftpFormat": {
+      "description": "The FTP format for this EDI",
+      "type": "string",
+      "enum": [
+        "SFTP",
+        "FTP"
+      ]
+    },
+    "ftpMode": {
+      "description": "The FTP mode for this EDI",
+      "type": "string",
+      "enum": [
+        "ASCII",
+        "Binary"
+      ]
+    },
+    "ftpPort": {
+      "description": "The port for this EDI",
+      "type": "integer"
+    },
+    "invoiceDirectory": {
+      "description": "The invoice directory for this EDI",
+      "type": "string"
+    },
+    "isPrimaryTransmissionMethod": {
+      "description": "Primary transmission method",
+      "type": "boolean"
+    },
+    "notes": {
+      "description": "The notes for this EDI",
+      "type": "string"
+    },
+    "orderDirectory": {
+      "description": "The order directory for this EDI",
+      "type": "string"
+    },
+    "password": {
+      "description": "The login password for this EDI",
+      "type": "string"
+    },
+    "serverAddress": {
+      "description": "The server address for this EDI",
+      "type": "string"
+    },
+    "username": {
+      "description": "The login username for this EDI",
+      "type": "string"
+    }
+  },
+  "additionalProperties": false
+}

--- a/mod-orgs/schemas/edi_schedule.json
+++ b/mod-orgs/schemas/edi_schedule.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "The job object for this EDI",
+  "type": "object",
+  "properties": {
+    "enableScheduledExport": {
+      "description": "Whether or not to enable scheduled for exports",
+      "type": "boolean",
+      "default": false
+    },
+    "scheduleParameters": {
+      "$ref": "schedule_parameters.json"
+    },
+    "schedulingNotes": {
+      "description": "The schedule notes for this EDI job",
+      "type": "string"
+    }
+  },
+  "additionalProperties": false
+}

--- a/mod-orgs/schemas/edi_schedule.json
+++ b/mod-orgs/schemas/edi_schedule.json
@@ -9,6 +9,7 @@
       "default": false
     },
     "scheduleParameters": {
+      "description": "Job scheduler parameters",
       "$ref": "schedule_parameters.json"
     },
     "schedulingNotes": {

--- a/mod-orgs/schemas/integration_detail.json
+++ b/mod-orgs/schemas/integration_detail.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "EDI config",
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "The unique id of this email",
+      "$ref": "../../common/schemas/uuid.json"
+    },
+    "_version": {
+      "type": "integer",
+      "description": "Record version for optimistic locking"
+    },
+    "exportConfigId" : {
+      "description": "UUID of the export configuration. Needed to find Jobs by export config UUID",
+      "$ref": "../../common/schemas/uuid.json"
+    },
+    "vendorId": {
+      "description": "UUID of the acquisition method",
+      "$ref": "../../common/schemas/uuid.json"
+    },
+    "configName": {
+      "description": "Configuration name",
+      "type": "string"
+    },
+    "configDescription": {
+      "description": "Configuration description",
+      "type": "string"
+    },
+    "ediConfig": {
+      "description": "EDI config for this vendor",
+      "$ref": "edi_config.json"
+    },
+    "ediFtp": {
+      "$ref": "edi_ftp.json"
+    },
+    "ediSchedule": {
+      "$ref": "edi_schedule.json"
+    },
+    "isDefaultConfig": {
+      "description": "If true then config is default",
+      "type": "boolean",
+      "default": false
+    },
+    "metadata": {
+      "type": "object",
+      "$ref": "../../../raml-util/schemas/metadata.schema",
+      "readonly": true
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "vendorId"
+  ]
+}

--- a/mod-orgs/schemas/integration_detail.json
+++ b/mod-orgs/schemas/integration_detail.json
@@ -32,9 +32,11 @@
       "$ref": "edi_config.json"
     },
     "ediFtp": {
+      "description": "The FTP object for this EDI",
       "$ref": "edi_ftp.json"
     },
     "ediSchedule": {
+      "description": "The job object for this EDI",
       "$ref": "edi_schedule.json"
     },
     "isDefaultConfig": {

--- a/mod-orgs/schemas/integration_detail_collection.json
+++ b/mod-orgs/schemas/integration_detail_collection.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Collection of integration detail records",
+  "type": "object",
+  "properties": {
+    "integrationDetails": {
+      "description": "The list of integration details in this collection",
+      "type": "array",
+      "id": "integrationDetails",
+      "items": {
+        "type": "object",
+        "$ref": "integration_detail.json"
+      }
+    },
+    "totalRecords": {
+      "description": "The number of integration detail records returned in this collection",
+      "type": "integer"
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "integrationDetails",
+    "totalRecords"
+  ]
+}

--- a/mod-orgs/schemas/schedule_parameters.json
+++ b/mod-orgs/schemas/schedule_parameters.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "The job object for this EDI",
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "Schedule unique identifier",
+      "type": "string",
+      "format": "uuid"
+    },
+    "scheduleFrequency": {
+      "type": "integer",
+      "description": "Number of time periods"
+    },
+    "schedulePeriod": {
+      "type": "string",
+      "description": "Time period for repeating job",
+      "enum": [
+        "MONTH",
+        "WEEK",
+        "DAY",
+        "HOUR",
+        "EXACT_DATE",
+        "NONE"
+      ]
+    },
+    "schedulingDate": {
+      "description": "The date (MM/DD/YYYY) for this job to start running",
+      "format": "date-time",
+      "type": "string"
+    },
+    "scheduleTime": {
+      "type": "string",
+      "description": "Time to run the job"
+    },
+    "scheduleDay": {
+      "type": "integer",
+      "description": "Day of month to run the job (One-based)"
+    },
+    "weekDays": {
+      "type": "array",
+      "description": "Day of week to run the job",
+      "items": {
+        "type": "string",
+        "description": "Day of week",
+        "enum": [
+          "MONDAY",
+          "TUESDAY",
+          "WEDNESDAY",
+          "THURSDAY",
+          "FRIDAY",
+          "SATURDAY",
+          "SUNDAY"
+        ]
+      }
+    },
+    "timeZone": {
+      "type": "string",
+      "description": "Schedule time zone",
+      "default": "UTC"
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Purpose

- <https://folio-org.atlassian.net/browse/MODORGSTOR-171>

## Approach

- Add RAML-compatible models based on this Spring Boot-compatible model:
  - <https://github.com/folio-org/folio-export-common/blob/master/schemas/acquisitions/vendorEdiOrdersExportConfig.json>
