### PR TITLE
[MODORDERS-1210] Add new collection for batch status update request body

### DIFF
--- a/mod-orders-storage/schemas/piece.json
+++ b/mod-orders-storage/schemas/piece.json
@@ -93,16 +93,7 @@
     },
     "receivingStatus": {
       "description": "The status of this piece",
-      "type": "string",
-      "enum": [
-        "Received",
-        "Expected",
-        "Late",
-        "Claim delayed",
-        "Claim sent",
-        "Unreceivable"
-      ],
-      "default": "Expected"
+      "$ref": "receiving_status.json"
     },
     "supplement": {
       "description": "Whether or not this is supplementary material",

--- a/mod-orders-storage/schemas/receiving_status.json
+++ b/mod-orders-storage/schemas/receiving_status.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "The status of a piece",
+  "javaName": "ReceivingStatus",
+  "type": "string",
+  "enum": [
+    "Received",
+    "Expected",
+    "Late",
+    "Claim delayed",
+    "Claim sent",
+    "Unreceivable"
+  ],
+  "default": "Expected"
+}

--- a/mod-orders/examples/pieceStatusBatchCollection.sample
+++ b/mod-orders/examples/pieceStatusBatchCollection.sample
@@ -1,0 +1,7 @@
+{
+  "pieceIds": [
+    "5f5b4f3b-6b7b-4b1e-8b4d-8b1b2b3b4b5b",
+    "5f5b4f3b-6b7b-4b1e-8b4d-8b1b2b3b4b5c"
+  ],
+  "receivingStatus": "Unreceivable"
+}

--- a/mod-orders/schemas/pieceStatusBatchCollection.json
+++ b/mod-orders/schemas/pieceStatusBatchCollection.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "A collection of piece ids and a new status to update",
+  "type": "object",
+  "properties": {
+    "pieceIds": {
+      "description": "A collection of piece ids to update",
+      "type": "array",
+      "id": "pieceIds",
+      "items": {
+        "type": "string",
+        "$ref": "../../common/schemas/uuid.json"
+      }
+    },
+    "receivingStatus": {
+      "description": "The new status of the corresponding pieces",
+      "$ref": "../../mod-orders-storage/schemas/receiving_status.json"
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "pieceIds",
+    "receivingStatus"
+  ]
+}


### PR DESCRIPTION
## Purpose
[[MODORDERS-1210] Implement API to change piece statuses in batch](https://folio-org.atlassian.net/browse/MODORDERS-1210)]

## Approach
- Add the model for request body