### PR TITLE
[MODORDERS-1237]. Add purchaseOrder and poLine objects

### DIFF
--- a/mod-orders-storage/examples/wrapper_piece_collection.sample
+++ b/mod-orders-storage/examples/wrapper_piece_collection.sample
@@ -1,6 +1,7 @@
 {
     "wrapperPieces": [
         {
+            "vendorId": "0b5e9284-fe9f-419d-b14e-319c7659165f",
             "piece": {
                 "id": "29c88d1a-e098-4f49-8074-917f5f5965d5",
                 "format": "Physical",

--- a/mod-orders-storage/examples/wrapper_piece_collection.sample
+++ b/mod-orders-storage/examples/wrapper_piece_collection.sample
@@ -1,28 +1,27 @@
 {
     "wrapperPieces": [
         {
-            "vendorId": "e0fb5df2-cdf1-11e8-a8d5-f2801f1b9fd1",
             "piece": {
-                "id": "5b59ae92-ee62-4545-a326-a5d6028b4ef5",
+                "id": "29c88d1a-e098-4f49-8074-917f5f5965d5",
                 "format": "Physical",
-                "itemId": "5ab64798-237e-4111-a7a5-53a01b1940ab",
-                "poLineId": "2113b1f7-db25-435a-91bd-406ee882f734",
-                "titleId": "e4f01c4b-54b6-4f21-91a7-eac5f191211b",
-                "holdingId": "4ae173c6-bf29-4c17-9630-e499772358dd",
+                "itemId": "db335665-5359-41ab-b530-f36c0967852f",
+                "poLineId": "d27efda0-0b01-4bc5-bf96-018598dc9a61",
+                "titleId": "07618e59-d9d9-4be0-b05b-7e471bca870e",
+                "holdingId": "4ae98814-da19-4f38-8483-6571970707d7",
                 "displayOnHolding": false,
                 "displayToPublic": false,
                 "receivingStatus": "Expected",
                 "isBound": false,
-                "statusUpdatedDate": "2025-01-21T09:45:45.372+00:00",
+                "statusUpdatedDate": "2025-01-21T08:08:52.883+00:00",
                 "metadata": {
-                    "createdDate": "2025-01-21T09:45:45.371+00:00",
-                    "createdByUserId": "5951b3e5-ee87-4359-ad44-5fcf309f17f9",
-                    "updatedDate": "2025-01-21T09:45:45.371+00:00",
-                    "updatedByUserId": "5951b3e5-ee87-4359-ad44-5fcf309f17f9"
+                    "createdDate": "2025-01-21T08:08:52.877+00:00",
+                    "createdByUserId": "13cf3da2-e87b-4719-aa19-9e751dee6c10",
+                    "updatedDate": "2025-01-21T08:08:52.877+00:00",
+                    "updatedByUserId": "13cf3da2-e87b-4719-aa19-9e751dee6c10"
                 }
             },
             "purchaseOrder": {
-                "id": "97147593-0f3f-4945-8f0d-739e89ee735e",
+                "id": "347aba4a-cdab-411d-880b-a63f8b696ec3",
                 "tags": {
                     "tagList": [
                         "amazon"
@@ -33,33 +32,52 @@
                 ],
                 "billTo": "5f8a321e-6b38-4d90-92d4-bf08f91a2242",
                 "shipTo": "f7c36792-05f7-4c8c-969d-103ac6763187",
-                "vendor": "e0fb5df2-cdf1-11e8-a8d5-f2801f1b9fd1",
+                "vendor": "0b5e9284-fe9f-419d-b14e-319c7659165f",
                 "approved": true,
                 "manualPo": false,
                 "metadata": {
-                    "createdDate": "2025-01-21T09:45:12.282Z",
-                    "updatedDate": "2025-01-21T09:45:45.508Z",
-                    "createdByUserId": "5951b3e5-ee87-4359-ad44-5fcf309f17f9",
-                    "updatedByUserId": "5951b3e5-ee87-4359-ad44-5fcf309f17f9"
+                    "createdDate": "2025-01-21T08:06:30.998Z",
+                    "updatedDate": "2025-01-21T08:08:53.155Z",
+                    "createdByUserId": "13cf3da2-e87b-4719-aa19-9e751dee6c10",
+                    "updatedByUserId": "13cf3da2-e87b-4719-aa19-9e751dee6c10"
                 },
-                "poNumber": "10013",
+                "poNumber": "10000",
                 "template": "4dee318b-f5b3-40dc-be93-cc89b8c45b6f",
                 "orderType": "One-Time",
                 "acqUnitIds": [],
                 "reEncumber": false,
-                "dateOrdered": "2025-01-21T09:45:43.602+00:00",
-                "approvalDate": "2025-01-21T09:45:43.602+00:00",
-                "approvedById": "5951b3e5-ee87-4359-ad44-5fcf309f17f9",
+                "dateOrdered": "2025-01-21T08:08:50.849+00:00",
+                "approvalDate": "2025-01-21T08:08:50.848+00:00",
+                "approvedById": "13cf3da2-e87b-4719-aa19-9e751dee6c10",
                 "workflowStatus": "Open"
             },
+            "title": {
+                "id": "07618e59-d9d9-4be0-b05b-7e471bca870e",
+                "title": "Test 1",
+                "metadata": {
+                    "createdDate": "2025-01-21T08:06:50.677Z",
+                    "updatedDate": "2025-01-21T08:08:53.122Z",
+                    "createdByUserId": "13cf3da2-e87b-4719-aa19-9e751dee6c10",
+                    "updatedByUserId": "13cf3da2-e87b-4719-aa19-9e751dee6c10"
+                },
+                "poLineId": "d27efda0-0b01-4bc5-bf96-018598dc9a61",
+                "acqUnitIds": [],
+                "instanceId": "7068d630-3809-423f-9f6a-6742812dddfb",
+                "productIds": [],
+                "bindItemIds": [],
+                "contributors": [],
+                "poLineNumber": "10000-1",
+                "claimingActive": false,
+                "isAcknowledged": false
+            },
             "poLine": {
-                "id": "2113b1f7-db25-435a-91bd-406ee882f734",
+                "id": "d27efda0-0b01-4bc5-bf96-018598dc9a61",
                 "cost": {
                     "currency": "USD",
                     "discountType": "percentage",
-                    "listUnitPrice": 99.0,
+                    "listUnitPrice": 100.0,
                     "quantityPhysical": 1,
-                    "poLineEstimatedPrice": 99.0
+                    "poLineEstimatedPrice": 100.0
                 },
                 "rush": false,
                 "alerts": [],
@@ -68,14 +86,13 @@
                 "details": {
                     "productIds": [],
                     "isAcknowledged": false,
-                    "isBinderyActive": false,
-                    "subscriptionInterval": 0
+                    "isBinderyActive": false
                 },
                 "metadata": {
-                    "createdDate": "2025-01-21T09:45:36.551Z",
-                    "updatedDate": "2025-01-21T09:45:45.452Z",
-                    "createdByUserId": "5951b3e5-ee87-4359-ad44-5fcf309f17f9",
-                    "updatedByUserId": "5951b3e5-ee87-4359-ad44-5fcf309f17f9"
+                    "createdDate": "2025-01-21T08:06:50.595Z",
+                    "updatedDate": "2025-01-21T08:08:53.096Z",
+                    "createdByUserId": "13cf3da2-e87b-4719-aa19-9e751dee6c10",
+                    "updatedByUserId": "13cf3da2-e87b-4719-aa19-9e751dee6c10"
                 },
                 "physical": {
                     "volumes": [],
@@ -87,29 +104,28 @@
                 "locations": [
                     {
                         "quantity": 1,
-                        "holdingId": "4ae173c6-bf29-4c17-9630-e499772358dd",
+                        "holdingId": "4ae98814-da19-4f38-8483-6571970707d7",
                         "quantityPhysical": 1
                     }
                 ],
                 "collection": false,
-                "instanceId": "45102f9b-9eaa-4805-ad98-d1454bff391f",
+                "instanceId": "7068d630-3809-423f-9f6a-6742812dddfb",
                 "orderFormat": "Physical Resource",
                 "checkinItems": false,
                 "contributors": [],
-                "poLineNumber": "10013-1",
+                "poLineNumber": "10000-1",
                 "vendorDetail": {
                     "instructions": "",
-                    "vendorAccount": "1234",
+                    "vendorAccount": "1",
                     "referenceNumbers": []
                 },
                 "paymentStatus": "Awaiting Payment",
                 "receiptStatus": "Awaiting Receipt",
                 "claimingActive": false,
                 "reportingCodes": [],
-                "titleOrPackage": "Claim Filter Test 1",
+                "titleOrPackage": "Test 1",
                 "automaticExport": false,
-                "purchaseOrderId": "97147593-0f3f-4945-8f0d-739e89ee735e",
-                "claimingInterval": 45,
+                "purchaseOrderId": "347aba4a-cdab-411d-880b-a63f8b696ec3",
                 "fundDistribution": [],
                 "acquisitionMethod": "306489dd-0053-49ee-a068-c316444a8f55",
                 "searchLocationIds": [

--- a/mod-orders-storage/examples/wrapper_piece_collection.sample
+++ b/mod-orders-storage/examples/wrapper_piece_collection.sample
@@ -1,129 +1,124 @@
 {
     "wrapperPieces": [
         {
-            "vendorId": "09e1ff42-1da7-450d-9857-157fa2a1446d",
+            "vendorId": "e0fb5df2-cdf1-11e8-a8d5-f2801f1b9fd1",
             "piece": {
-                "id": "203dff6d-1d58-47d8-986b-395e13a2b381",
-                "displaySummary": "Test 1-1-1",
+                "id": "5b59ae92-ee62-4545-a326-a5d6028b4ef5",
                 "format": "Physical",
-                "itemId": "35bcac8f-d649-4d9b-a16c-3bb6b6be5e61",
-                "poLineId": "3de0a931-be1a-4749-8ed0-3fd0bcb6ee91",
-                "titleId": "ba4f552b-7263-463e-bc7c-42ab6fab60e0",
-                "holdingId": "81a1e03f-75a7-41d5-a257-53d158b7d1cf",
+                "itemId": "5ab64798-237e-4111-a7a5-53a01b1940ab",
+                "poLineId": "2113b1f7-db25-435a-91bd-406ee882f734",
+                "titleId": "e4f01c4b-54b6-4f21-91a7-eac5f191211b",
+                "holdingId": "4ae173c6-bf29-4c17-9630-e499772358dd",
                 "displayOnHolding": false,
                 "displayToPublic": false,
-                "discoverySuppress": false,
                 "receivingStatus": "Expected",
-                "supplement": false,
                 "isBound": false,
-                "statusUpdatedDate": "2025-01-20T07:05:45.339+00:00",
+                "statusUpdatedDate": "2025-01-21T09:45:45.372+00:00",
                 "metadata": {
-                    "createdDate": "2025-01-20T07:05:45.335+00:00",
-                    "createdByUserId": "15f7cf1e-de8c-46c3-bb8a-c963064442f5",
-                    "updatedDate": "2025-01-20T07:06:46.177+00:00",
-                    "updatedByUserId": "15f7cf1e-de8c-46c3-bb8a-c963064442f5"
+                    "createdDate": "2025-01-21T09:45:45.371+00:00",
+                    "createdByUserId": "5951b3e5-ee87-4359-ad44-5fcf309f17f9",
+                    "updatedDate": "2025-01-21T09:45:45.371+00:00",
+                    "updatedByUserId": "5951b3e5-ee87-4359-ad44-5fcf309f17f9"
                 }
-            }
-        },
-        {
-            "vendorId": "09e1ff42-1da7-450d-9857-157fa2a1446d",
-            "piece": {
-                "id": "de37ee87-619d-481e-8dc7-78d312994e1d",
-                "displaySummary": "Test 1-1-2",
-                "format": "Physical",
-                "itemId": "0d59ade0-46c1-4abe-8ead-cec490965c67",
-                "poLineId": "3de0a931-be1a-4749-8ed0-3fd0bcb6ee91",
-                "titleId": "ba4f552b-7263-463e-bc7c-42ab6fab60e0",
-                "holdingId": "81a1e03f-75a7-41d5-a257-53d158b7d1cf",
-                "displayOnHolding": false,
-                "displayToPublic": false,
-                "discoverySuppress": false,
-                "receivingStatus": "Expected",
-                "supplement": false,
-                "isBound": false,
-                "statusUpdatedDate": "2025-01-20T07:06:53.900+00:00",
+            },
+            "purchaseOrder": {
+                "id": "97147593-0f3f-4945-8f0d-739e89ee735e",
+                "tags": {
+                    "tagList": [
+                        "amazon"
+                    ]
+                },
+                "notes": [
+                    "Check credit card statement to make sure payment shows up"
+                ],
+                "billTo": "5f8a321e-6b38-4d90-92d4-bf08f91a2242",
+                "shipTo": "f7c36792-05f7-4c8c-969d-103ac6763187",
+                "vendor": "e0fb5df2-cdf1-11e8-a8d5-f2801f1b9fd1",
+                "approved": true,
+                "manualPo": false,
                 "metadata": {
-                    "createdDate": "2025-01-20T07:06:53.899+00:00",
-                    "createdByUserId": "15f7cf1e-de8c-46c3-bb8a-c963064442f5",
-                    "updatedDate": "2025-01-20T07:06:53.899+00:00",
-                    "updatedByUserId": "15f7cf1e-de8c-46c3-bb8a-c963064442f5"
-                }
-            }
-        },
-        {
-            "vendorId": "09e1ff42-1da7-450d-9857-157fa2a1446d",
-            "piece": {
-                "id": "e3805224-b3c8-47b6-88cf-892d3d543820",
-                "displaySummary": "Test 1-1-3",
-                "format": "Physical",
-                "poLineId": "3de0a931-be1a-4749-8ed0-3fd0bcb6ee91",
-                "titleId": "ba4f552b-7263-463e-bc7c-42ab6fab60e0",
-                "holdingId": "81a1e03f-75a7-41d5-a257-53d158b7d1cf",
-                "displayOnHolding": false,
-                "displayToPublic": false,
-                "discoverySuppress": false,
-                "receivingStatus": "Expected",
-                "supplement": false,
-                "isBound": false,
-                "statusUpdatedDate": "2025-01-20T07:07:01.667+00:00",
+                    "createdDate": "2025-01-21T09:45:12.282Z",
+                    "updatedDate": "2025-01-21T09:45:45.508Z",
+                    "createdByUserId": "5951b3e5-ee87-4359-ad44-5fcf309f17f9",
+                    "updatedByUserId": "5951b3e5-ee87-4359-ad44-5fcf309f17f9"
+                },
+                "poNumber": "10013",
+                "template": "4dee318b-f5b3-40dc-be93-cc89b8c45b6f",
+                "orderType": "One-Time",
+                "acqUnitIds": [],
+                "reEncumber": false,
+                "dateOrdered": "2025-01-21T09:45:43.602+00:00",
+                "approvalDate": "2025-01-21T09:45:43.602+00:00",
+                "approvedById": "5951b3e5-ee87-4359-ad44-5fcf309f17f9",
+                "workflowStatus": "Open"
+            },
+            "poLine": {
+                "id": "2113b1f7-db25-435a-91bd-406ee882f734",
+                "cost": {
+                    "currency": "USD",
+                    "discountType": "percentage",
+                    "listUnitPrice": 99.0,
+                    "quantityPhysical": 1,
+                    "poLineEstimatedPrice": 99.0
+                },
+                "rush": false,
+                "alerts": [],
+                "claims": [],
+                "source": "User",
+                "details": {
+                    "productIds": [],
+                    "isAcknowledged": false,
+                    "isBinderyActive": false,
+                    "subscriptionInterval": 0
+                },
                 "metadata": {
-                    "createdDate": "2025-01-20T07:07:01.665+00:00",
-                    "createdByUserId": "15f7cf1e-de8c-46c3-bb8a-c963064442f5",
-                    "updatedDate": "2025-01-20T07:07:01.665+00:00",
-                    "updatedByUserId": "15f7cf1e-de8c-46c3-bb8a-c963064442f5"
-                }
-            }
-        },
-        {
-            "vendorId": "c1368745-3cf7-4052-a13a-fa094ca36bd1",
-            "piece": {
-                "id": "296b80dd-809e-4dcf-820a-0598f6a7861c",
-                "displaySummary": "Test 2-1-1",
-                "format": "Physical",
-                "itemId": "d1627a88-e76a-41b0-8371-96c7c8c0eaac",
-                "poLineId": "a9b985ce-c73a-4784-9dda-d0fdc785c735",
-                "titleId": "e6d3198d-4fb8-4b6c-adf1-42bf3746d202",
-                "holdingId": "ebf68b14-d10f-4f76-a026-c15e6e406903",
-                "displayOnHolding": false,
-                "displayToPublic": false,
-                "discoverySuppress": false,
-                "receivingStatus": "Expected",
-                "supplement": false,
-                "isBound": false,
-                "statusUpdatedDate": "2025-01-20T07:06:29.785+00:00",
-                "metadata": {
-                    "createdDate": "2025-01-20T07:06:29.783+00:00",
-                    "createdByUserId": "15f7cf1e-de8c-46c3-bb8a-c963064442f5",
-                    "updatedDate": "2025-01-20T07:07:27.276+00:00",
-                    "updatedByUserId": "15f7cf1e-de8c-46c3-bb8a-c963064442f5"
-                }
-            }
-        },
-        {
-            "vendorId": "c1368745-3cf7-4052-a13a-fa094ca36bd1",
-            "piece": {
-                "id": "cf1bdbc4-8114-4e9b-b13c-50b93783a4e0",
-                "displaySummary": "Test 2-1-2",
-                "format": "Physical",
-                "itemId": "b61f1db1-c7b6-4aec-9a09-35f39bf392fe",
-                "poLineId": "a9b985ce-c73a-4784-9dda-d0fdc785c735",
-                "titleId": "e6d3198d-4fb8-4b6c-adf1-42bf3746d202",
-                "holdingId": "ebf68b14-d10f-4f76-a026-c15e6e406903",
-                "displayOnHolding": false,
-                "displayToPublic": false,
-                "discoverySuppress": false,
-                "receivingStatus": "Expected",
-                "supplement": false,
-                "isBound": false,
-                "statusUpdatedDate": "2025-01-20T07:07:40.096+00:00",
-                "metadata": {
-                    "createdDate": "2025-01-20T07:07:40.094+00:00",
-                    "createdByUserId": "15f7cf1e-de8c-46c3-bb8a-c963064442f5",
-                    "updatedDate": "2025-01-20T07:07:40.094+00:00",
-                    "updatedByUserId": "15f7cf1e-de8c-46c3-bb8a-c963064442f5"
-                }
+                    "createdDate": "2025-01-21T09:45:36.551Z",
+                    "updatedDate": "2025-01-21T09:45:45.452Z",
+                    "createdByUserId": "5951b3e5-ee87-4359-ad44-5fcf309f17f9",
+                    "updatedByUserId": "5951b3e5-ee87-4359-ad44-5fcf309f17f9"
+                },
+                "physical": {
+                    "volumes": [],
+                    "materialType": "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+                    "createInventory": "Instance, Holding, Item",
+                    "materialSupplier": "e0fb5df2-cdf1-11e8-a8d5-f2801f1b9fd1"
+                },
+                "isPackage": false,
+                "locations": [
+                    {
+                        "quantity": 1,
+                        "holdingId": "4ae173c6-bf29-4c17-9630-e499772358dd",
+                        "quantityPhysical": 1
+                    }
+                ],
+                "collection": false,
+                "instanceId": "45102f9b-9eaa-4805-ad98-d1454bff391f",
+                "orderFormat": "Physical Resource",
+                "checkinItems": false,
+                "contributors": [],
+                "poLineNumber": "10013-1",
+                "vendorDetail": {
+                    "instructions": "",
+                    "vendorAccount": "1234",
+                    "referenceNumbers": []
+                },
+                "paymentStatus": "Awaiting Payment",
+                "receiptStatus": "Awaiting Receipt",
+                "claimingActive": false,
+                "reportingCodes": [],
+                "titleOrPackage": "Claim Filter Test 1",
+                "automaticExport": false,
+                "purchaseOrderId": "97147593-0f3f-4945-8f0d-739e89ee735e",
+                "claimingInterval": 45,
+                "fundDistribution": [],
+                "acquisitionMethod": "306489dd-0053-49ee-a068-c316444a8f55",
+                "searchLocationIds": [
+                    "fcd64ce1-6995-48f0-840e-89ffa2288371"
+                ],
+                "donorOrganizationIds": [],
+                "cancellationRestriction": true
             }
         }
     ],
-    "totalRecords": 5
+    "totalRecords": 1
 }

--- a/mod-orders-storage/examples/wrapper_piece_get.sample
+++ b/mod-orders-storage/examples/wrapper_piece_get.sample
@@ -1,25 +1,119 @@
 {
-    "vendorId": "09e1ff42-1da7-450d-9857-157fa2a1446d",
+    "vendorId": "e0fb5df2-cdf1-11e8-a8d5-f2801f1b9fd1",
     "piece": {
-        "id": "203dff6d-1d58-47d8-986b-395e13a2b381",
-        "displaySummary": "Test 1-1-1",
+        "id": "5b59ae92-ee62-4545-a326-a5d6028b4ef5",
         "format": "Physical",
-        "itemId": "35bcac8f-d649-4d9b-a16c-3bb6b6be5e61",
-        "poLineId": "3de0a931-be1a-4749-8ed0-3fd0bcb6ee91",
-        "titleId": "ba4f552b-7263-463e-bc7c-42ab6fab60e0",
-        "holdingId": "81a1e03f-75a7-41d5-a257-53d158b7d1cf",
+        "itemId": "5ab64798-237e-4111-a7a5-53a01b1940ab",
+        "poLineId": "2113b1f7-db25-435a-91bd-406ee882f734",
+        "titleId": "e4f01c4b-54b6-4f21-91a7-eac5f191211b",
+        "holdingId": "4ae173c6-bf29-4c17-9630-e499772358dd",
         "displayOnHolding": false,
         "displayToPublic": false,
-        "discoverySuppress": false,
         "receivingStatus": "Expected",
-        "supplement": false,
         "isBound": false,
-        "statusUpdatedDate": "2025-01-20T07:05:45.339+00:00",
+        "statusUpdatedDate": "2025-01-21T09:45:45.372+00:00",
         "metadata": {
-            "createdDate": "2025-01-20T07:05:45.335+00:00",
-            "createdByUserId": "15f7cf1e-de8c-46c3-bb8a-c963064442f5",
-            "updatedDate": "2025-01-20T07:06:46.177+00:00",
-            "updatedByUserId": "15f7cf1e-de8c-46c3-bb8a-c963064442f5"
+            "createdDate": "2025-01-21T09:45:45.371+00:00",
+            "createdByUserId": "5951b3e5-ee87-4359-ad44-5fcf309f17f9",
+            "updatedDate": "2025-01-21T09:45:45.371+00:00",
+            "updatedByUserId": "5951b3e5-ee87-4359-ad44-5fcf309f17f9"
         }
+    },
+    "purchaseOrder": {
+        "id": "97147593-0f3f-4945-8f0d-739e89ee735e",
+        "tags": {
+            "tagList": [
+                "amazon"
+            ]
+        },
+        "notes": [
+            "Check credit card statement to make sure payment shows up"
+        ],
+        "billTo": "5f8a321e-6b38-4d90-92d4-bf08f91a2242",
+        "shipTo": "f7c36792-05f7-4c8c-969d-103ac6763187",
+        "vendor": "e0fb5df2-cdf1-11e8-a8d5-f2801f1b9fd1",
+        "approved": true,
+        "manualPo": false,
+        "metadata": {
+            "createdDate": "2025-01-21T09:45:12.282Z",
+            "updatedDate": "2025-01-21T09:45:45.508Z",
+            "createdByUserId": "5951b3e5-ee87-4359-ad44-5fcf309f17f9",
+            "updatedByUserId": "5951b3e5-ee87-4359-ad44-5fcf309f17f9"
+        },
+        "poNumber": "10013",
+        "template": "4dee318b-f5b3-40dc-be93-cc89b8c45b6f",
+        "orderType": "One-Time",
+        "acqUnitIds": [],
+        "reEncumber": false,
+        "dateOrdered": "2025-01-21T09:45:43.602+00:00",
+        "approvalDate": "2025-01-21T09:45:43.602+00:00",
+        "approvedById": "5951b3e5-ee87-4359-ad44-5fcf309f17f9",
+        "workflowStatus": "Open"
+    },
+    "poLine": {
+        "id": "2113b1f7-db25-435a-91bd-406ee882f734",
+        "cost": {
+            "currency": "USD",
+            "discountType": "percentage",
+            "listUnitPrice": 99.0,
+            "quantityPhysical": 1,
+            "poLineEstimatedPrice": 99.0
+        },
+        "rush": false,
+        "alerts": [],
+        "claims": [],
+        "source": "User",
+        "details": {
+            "productIds": [],
+            "isAcknowledged": false,
+            "isBinderyActive": false,
+            "subscriptionInterval": 0
+        },
+        "metadata": {
+            "createdDate": "2025-01-21T09:45:36.551Z",
+            "updatedDate": "2025-01-21T09:45:45.452Z",
+            "createdByUserId": "5951b3e5-ee87-4359-ad44-5fcf309f17f9",
+            "updatedByUserId": "5951b3e5-ee87-4359-ad44-5fcf309f17f9"
+        },
+        "physical": {
+            "volumes": [],
+            "materialType": "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+            "createInventory": "Instance, Holding, Item",
+            "materialSupplier": "e0fb5df2-cdf1-11e8-a8d5-f2801f1b9fd1"
+        },
+        "isPackage": false,
+        "locations": [
+            {
+                "quantity": 1,
+                "holdingId": "4ae173c6-bf29-4c17-9630-e499772358dd",
+                "quantityPhysical": 1
+            }
+        ],
+        "collection": false,
+        "instanceId": "45102f9b-9eaa-4805-ad98-d1454bff391f",
+        "orderFormat": "Physical Resource",
+        "checkinItems": false,
+        "contributors": [],
+        "poLineNumber": "10013-1",
+        "vendorDetail": {
+            "instructions": "",
+            "vendorAccount": "1234",
+            "referenceNumbers": []
+        },
+        "paymentStatus": "Awaiting Payment",
+        "receiptStatus": "Awaiting Receipt",
+        "claimingActive": false,
+        "reportingCodes": [],
+        "titleOrPackage": "Claim Filter Test 1",
+        "automaticExport": false,
+        "purchaseOrderId": "97147593-0f3f-4945-8f0d-739e89ee735e",
+        "claimingInterval": 45,
+        "fundDistribution": [],
+        "acquisitionMethod": "306489dd-0053-49ee-a068-c316444a8f55",
+        "searchLocationIds": [
+            "fcd64ce1-6995-48f0-840e-89ffa2288371"
+        ],
+        "donorOrganizationIds": [],
+        "cancellationRestriction": true
     }
 }

--- a/mod-orders-storage/examples/wrapper_piece_get.sample
+++ b/mod-orders-storage/examples/wrapper_piece_get.sample
@@ -1,26 +1,25 @@
 {
-    "vendorId": "e0fb5df2-cdf1-11e8-a8d5-f2801f1b9fd1",
     "piece": {
-        "id": "5b59ae92-ee62-4545-a326-a5d6028b4ef5",
+        "id": "29c88d1a-e098-4f49-8074-917f5f5965d5",
         "format": "Physical",
-        "itemId": "5ab64798-237e-4111-a7a5-53a01b1940ab",
-        "poLineId": "2113b1f7-db25-435a-91bd-406ee882f734",
-        "titleId": "e4f01c4b-54b6-4f21-91a7-eac5f191211b",
-        "holdingId": "4ae173c6-bf29-4c17-9630-e499772358dd",
+        "itemId": "db335665-5359-41ab-b530-f36c0967852f",
+        "poLineId": "d27efda0-0b01-4bc5-bf96-018598dc9a61",
+        "titleId": "07618e59-d9d9-4be0-b05b-7e471bca870e",
+        "holdingId": "4ae98814-da19-4f38-8483-6571970707d7",
         "displayOnHolding": false,
         "displayToPublic": false,
         "receivingStatus": "Expected",
         "isBound": false,
-        "statusUpdatedDate": "2025-01-21T09:45:45.372+00:00",
+        "statusUpdatedDate": "2025-01-21T08:08:52.883+00:00",
         "metadata": {
-            "createdDate": "2025-01-21T09:45:45.371+00:00",
-            "createdByUserId": "5951b3e5-ee87-4359-ad44-5fcf309f17f9",
-            "updatedDate": "2025-01-21T09:45:45.371+00:00",
-            "updatedByUserId": "5951b3e5-ee87-4359-ad44-5fcf309f17f9"
+            "createdDate": "2025-01-21T08:08:52.877+00:00",
+            "createdByUserId": "13cf3da2-e87b-4719-aa19-9e751dee6c10",
+            "updatedDate": "2025-01-21T08:08:52.877+00:00",
+            "updatedByUserId": "13cf3da2-e87b-4719-aa19-9e751dee6c10"
         }
     },
     "purchaseOrder": {
-        "id": "97147593-0f3f-4945-8f0d-739e89ee735e",
+        "id": "347aba4a-cdab-411d-880b-a63f8b696ec3",
         "tags": {
             "tagList": [
                 "amazon"
@@ -31,33 +30,52 @@
         ],
         "billTo": "5f8a321e-6b38-4d90-92d4-bf08f91a2242",
         "shipTo": "f7c36792-05f7-4c8c-969d-103ac6763187",
-        "vendor": "e0fb5df2-cdf1-11e8-a8d5-f2801f1b9fd1",
+        "vendor": "0b5e9284-fe9f-419d-b14e-319c7659165f",
         "approved": true,
         "manualPo": false,
         "metadata": {
-            "createdDate": "2025-01-21T09:45:12.282Z",
-            "updatedDate": "2025-01-21T09:45:45.508Z",
-            "createdByUserId": "5951b3e5-ee87-4359-ad44-5fcf309f17f9",
-            "updatedByUserId": "5951b3e5-ee87-4359-ad44-5fcf309f17f9"
+            "createdDate": "2025-01-21T08:06:30.998Z",
+            "updatedDate": "2025-01-21T08:08:53.155Z",
+            "createdByUserId": "13cf3da2-e87b-4719-aa19-9e751dee6c10",
+            "updatedByUserId": "13cf3da2-e87b-4719-aa19-9e751dee6c10"
         },
-        "poNumber": "10013",
+        "poNumber": "10000",
         "template": "4dee318b-f5b3-40dc-be93-cc89b8c45b6f",
         "orderType": "One-Time",
         "acqUnitIds": [],
         "reEncumber": false,
-        "dateOrdered": "2025-01-21T09:45:43.602+00:00",
-        "approvalDate": "2025-01-21T09:45:43.602+00:00",
-        "approvedById": "5951b3e5-ee87-4359-ad44-5fcf309f17f9",
+        "dateOrdered": "2025-01-21T08:08:50.849+00:00",
+        "approvalDate": "2025-01-21T08:08:50.848+00:00",
+        "approvedById": "13cf3da2-e87b-4719-aa19-9e751dee6c10",
         "workflowStatus": "Open"
     },
+    "title": {
+        "id": "07618e59-d9d9-4be0-b05b-7e471bca870e",
+        "title": "Test 1",
+        "metadata": {
+            "createdDate": "2025-01-21T08:06:50.677Z",
+            "updatedDate": "2025-01-21T08:08:53.122Z",
+            "createdByUserId": "13cf3da2-e87b-4719-aa19-9e751dee6c10",
+            "updatedByUserId": "13cf3da2-e87b-4719-aa19-9e751dee6c10"
+        },
+        "poLineId": "d27efda0-0b01-4bc5-bf96-018598dc9a61",
+        "acqUnitIds": [],
+        "instanceId": "7068d630-3809-423f-9f6a-6742812dddfb",
+        "productIds": [],
+        "bindItemIds": [],
+        "contributors": [],
+        "poLineNumber": "10000-1",
+        "claimingActive": false,
+        "isAcknowledged": false
+    },
     "poLine": {
-        "id": "2113b1f7-db25-435a-91bd-406ee882f734",
+        "id": "d27efda0-0b01-4bc5-bf96-018598dc9a61",
         "cost": {
             "currency": "USD",
             "discountType": "percentage",
-            "listUnitPrice": 99.0,
+            "listUnitPrice": 100.0,
             "quantityPhysical": 1,
-            "poLineEstimatedPrice": 99.0
+            "poLineEstimatedPrice": 100.0
         },
         "rush": false,
         "alerts": [],
@@ -66,14 +84,13 @@
         "details": {
             "productIds": [],
             "isAcknowledged": false,
-            "isBinderyActive": false,
-            "subscriptionInterval": 0
+            "isBinderyActive": false
         },
         "metadata": {
-            "createdDate": "2025-01-21T09:45:36.551Z",
-            "updatedDate": "2025-01-21T09:45:45.452Z",
-            "createdByUserId": "5951b3e5-ee87-4359-ad44-5fcf309f17f9",
-            "updatedByUserId": "5951b3e5-ee87-4359-ad44-5fcf309f17f9"
+            "createdDate": "2025-01-21T08:06:50.595Z",
+            "updatedDate": "2025-01-21T08:08:53.096Z",
+            "createdByUserId": "13cf3da2-e87b-4719-aa19-9e751dee6c10",
+            "updatedByUserId": "13cf3da2-e87b-4719-aa19-9e751dee6c10"
         },
         "physical": {
             "volumes": [],
@@ -85,29 +102,28 @@
         "locations": [
             {
                 "quantity": 1,
-                "holdingId": "4ae173c6-bf29-4c17-9630-e499772358dd",
+                "holdingId": "4ae98814-da19-4f38-8483-6571970707d7",
                 "quantityPhysical": 1
             }
         ],
         "collection": false,
-        "instanceId": "45102f9b-9eaa-4805-ad98-d1454bff391f",
+        "instanceId": "7068d630-3809-423f-9f6a-6742812dddfb",
         "orderFormat": "Physical Resource",
         "checkinItems": false,
         "contributors": [],
-        "poLineNumber": "10013-1",
+        "poLineNumber": "10000-1",
         "vendorDetail": {
             "instructions": "",
-            "vendorAccount": "1234",
+            "vendorAccount": "1",
             "referenceNumbers": []
         },
         "paymentStatus": "Awaiting Payment",
         "receiptStatus": "Awaiting Receipt",
         "claimingActive": false,
         "reportingCodes": [],
-        "titleOrPackage": "Claim Filter Test 1",
+        "titleOrPackage": "Test 1",
         "automaticExport": false,
-        "purchaseOrderId": "97147593-0f3f-4945-8f0d-739e89ee735e",
-        "claimingInterval": 45,
+        "purchaseOrderId": "347aba4a-cdab-411d-880b-a63f8b696ec3",
         "fundDistribution": [],
         "acquisitionMethod": "306489dd-0053-49ee-a068-c316444a8f55",
         "searchLocationIds": [

--- a/mod-orders-storage/examples/wrapper_piece_get.sample
+++ b/mod-orders-storage/examples/wrapper_piece_get.sample
@@ -1,4 +1,5 @@
 {
+    "vendorId": "0b5e9284-fe9f-419d-b14e-319c7659165f",
     "piece": {
         "id": "29c88d1a-e098-4f49-8074-917f5f5965d5",
         "format": "Physical",

--- a/mod-orders-storage/schemas/wrapper_piece.json
+++ b/mod-orders-storage/schemas/wrapper_piece.json
@@ -11,11 +11,21 @@
     "piece": {
       "description": "Piece details",
       "$ref": "piece.json"
+    },
+    "poLine": {
+      "description": "PoLine details",
+      "$ref": "po_line.json"
+    },
+    "purchaseOrder": {
+      "description": "PurchaseOrder details",
+      "$ref": "purchase_order.json"
     }
   },
   "additionalProperties": true,
   "required": [
     "vendorId",
-    "piece"
+    "piece",
+    "poLine",
+    "purchaseOrder"
   ]
 }

--- a/mod-orders-storage/schemas/wrapper_piece.json
+++ b/mod-orders-storage/schemas/wrapper_piece.json
@@ -16,6 +16,10 @@
       "description": "PoLine details",
       "$ref": "po_line.json"
     },
+    "title": {
+      "description": "Title details",
+      "$ref": "title.json"
+    },
     "purchaseOrder": {
       "description": "PurchaseOrder details",
       "$ref": "purchase_order.json"
@@ -26,6 +30,7 @@
     "vendorId",
     "piece",
     "poLine",
+    "title",
     "purchaseOrder"
   ]
 }


### PR DESCRIPTION
## Purpose

- <https://folio-org.atlassian.net/browse/MODORDERS-1237>

## Approach

- Add additional `purchaseOrder`, `poLine` and `title` objects to `wrapper_piece.json` needed for effective filtering and sorting as required by the Claiming app