### PR TITLE
[MODFIN-416]. Batch allocation logs - restrict by acq units

### DIFF
--- a/mod-finance/examples/fund_update_log.sample
+++ b/mod-finance/examples/fund_update_log.sample
@@ -8,6 +8,8 @@
   },
   "status": "IN_PROGRESS",
   "recordsCount": 100,
+  "ledgerId": "f4c51b26-d47b-4f63-af09-ef1e06bc3740",
+  "acqUnitIds": [],
   "metadata": {
     "createdDate": "2023-10-01T12:00:00Z",
     "createdByUserId": "d93373df-e7ec-4d31-b200-719736610d89",

--- a/mod-finance/schemas/fund_update_log.json
+++ b/mod-finance/schemas/fund_update_log.json
@@ -36,6 +36,17 @@
       "description": "The count of records",
       "type": "integer"
     },
+    "ledgerId": {
+      "description": "UUID of the ledger",
+      "$ref": "../../common/schemas/uuid.json"
+    },
+    "acqUnitIds": {
+      "description": "Acquisition unit ids associated with the ledger",
+      "type": "array",
+      "items": {
+        "$ref": "../../common/schemas/uuid.json"
+      }
+    },
     "metadata": {
       "type": "object",
       "$ref": "../../../raml-util/schemas/metadata.schema",

--- a/mod-finance/schemas/fund_update_log.json
+++ b/mod-finance/schemas/fund_update_log.json
@@ -53,8 +53,10 @@
       "readonly": true
     }
   },
-  "additionalProperties": false,
+  "additionalProperties": true,
   "required": [
-    "jobName"
+    "jobName",
+    "ledgerId",
+    "acqUnitIds"
   ]
 }


### PR DESCRIPTION
## Purpose

- <https://folio-org.atlassian.net/browse/MODFIN-416>

## Approach

- Add `ledgerId` and `acqUnitIds` to the schema to improve filtering by AcqUnits, and make the schema open for potential ledger cascade deletion