### PR TITLE
[MODORDERS-1262]. ECS | Piece could not be moved to "Claim sent" stat…

### DIFF
--- a/mod-orders/examples/claimingCollection.sample
+++ b/mod-orders/examples/claimingCollection.sample
@@ -1,7 +1,13 @@
 {
-  "claimingPieceIds": [
-    "123e4567-e89b-12d3-a456-426614174000",
-    "123e4567-e89b-12d3-a456-426614174001"
+  "claimingPieces": [
+    {
+      "id": "123e4567-e89b-12d3-a456-426614174000",
+      "receivingTenantId": "college"
+    },
+    {
+      "id": "123e4567-e89b-12d3-a456-426614174001",
+      "receivingTenantId": "university"
+    }
   ],
   "claimingInterval": 1,
   "internalNote": "internal",

--- a/mod-orders/schemas/claimingCollection.json
+++ b/mod-orders/schemas/claimingCollection.json
@@ -16,7 +16,7 @@
             "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
           },
           "receivingTenantId": {
-            "description": "The tenant id where piece should be claimed",
+            "description": "The member tenant id where piece should be received, checked or claimed",
             "type": "string"
           }
         },

--- a/mod-orders/schemas/claimingCollection.json
+++ b/mod-orders/schemas/claimingCollection.json
@@ -3,14 +3,24 @@
   "description": "A collection of claiming pieces",
   "type": "object",
   "properties": {
-    "claimingPieceIds": {
+    "claimingPieces": {
       "description": "List of claiming pieces",
-      "id": "claimingPieceIds",
+      "id": "claimingPieces",
       "type": "array",
       "items": {
-        "description": "The id of the piece",
-        "type": "string",
-        "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+        "type": "object",
+        "properties": {
+          "id": {
+            "description": "The id of the piece",
+            "type": "string",
+            "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+          },
+          "receivingTenantId": {
+            "description": "The tenant id where piece should be claimed",
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
       }
     },
     "claimingInterval": {
@@ -28,7 +38,7 @@
   },
   "additionalProperties": false,
   "required": [
-    "claimingPieceIds",
+    "claimingPieces",
     "claimingInterval"
   ]
 }


### PR DESCRIPTION
## Purpose

- <https://folio-org.atlassian.net/browse/MODORDERS-1262>

## Approach

- Add `receivingTenantId` to help distinguish Central tenant from member tenant if Central Ordering is enabled in ECS

> Pieces managed by central tenant will have `receivingTenantId` populated, while it is null for member and single tenant variants