### PR TITLE
MODORDSTOR-444: order_format.json is string, not object

### DIFF
--- a/mod-orders-storage/schemas/po_line.json
+++ b/mod-orders-storage/schemas/po_line.json
@@ -156,7 +156,7 @@
     },
     "orderFormat": {
       "description": "The purchase order line format",
-      "type": "object",
+      "type": "string",
       "$ref": "order_format.json"
     },
     "packagePoLineId": {

--- a/mod-orders/schemas/composite_po_line.json
+++ b/mod-orders/schemas/composite_po_line.json
@@ -158,7 +158,7 @@
     },
     "orderFormat": {
       "description": "The purchase order line format",
-      "type": "object",
+      "type": "string",
       "$ref": "../../mod-orders-storage/schemas/order_format.json"
     },
     "packagePoLineId": {


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODORDSTOR-444

## Purpose
Fix wrong type in RAML *.json.

order_format.json is string, not object.

## Approach
Change from type "object" to type "string".

## Learning
Don't use type "object" for enum strings.

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Examples exist for all schemas
  - [x] Descriptions exist for all schema properties
  - [x] All schemas pass raml-cop linting
- Does this introduce breaking changes?
  - [x] There are no breaking changes in this PR.