### PR TITLE
[MODORG-34] Change category type to UUID

### DIFF
--- a/mod-orgs/schemas/address.json
+++ b/mod-orgs/schemas/address.json
@@ -37,10 +37,11 @@
     },
     "categories": {
       "id": "categories",
-      "description": "The list of categories for this organization address",
+      "description": "The list of category ids for this organization address",
       "type": "array",
       "items": {
-        "type": "string"
+        "description": "UUID of the organization category",
+        "$ref": "../../common/schemas/uuid.json"
       }
     },
     "language": {

--- a/mod-orgs/schemas/contact.json
+++ b/mod-orgs/schemas/contact.json
@@ -69,10 +69,10 @@
     },
     "categories": {
       "id": "contactCategory",
-      "description": "The list of contact categories associated with this organization contact person",
+      "description": "The list of category ids for this organization contact person",
       "type": "array",
       "items": {
-        "description": "UUID of the contact category",
+        "description": "UUID of the organization category",
         "$ref": "../../common/schemas/uuid.json"
       }
     },

--- a/mod-orgs/schemas/email.json
+++ b/mod-orgs/schemas/email.json
@@ -21,10 +21,11 @@
     },
     "categories": {
       "id": "categories",
-      "description": "The list of categories for this organization email",
+      "description": "The list of category ids for this organization email",
       "type": "array",
       "items": {
-        "type": "string"
+        "description": "UUID of the organization category",
+        "$ref": "../../common/schemas/uuid.json"
       }
     },
     "language": {

--- a/mod-orgs/schemas/phone_number.json
+++ b/mod-orgs/schemas/phone_number.json
@@ -13,10 +13,11 @@
     },
     "categories": {
       "id": "categories",
-      "description": "The list of categories for this organization phone",
+      "description": "The list of category ids for this organization phone",
       "type": "array",
       "items": {
-        "type": "string"
+        "description": "UUID of the organization category",
+        "$ref": "../../common/schemas/uuid.json"
       }
     },
     "type": {

--- a/mod-orgs/schemas/url.json
+++ b/mod-orgs/schemas/url.json
@@ -26,10 +26,11 @@
     },
     "categories": {
       "id": "categories",
-      "description": "The list of categories for this organization URL",
+      "description": "The list of category ids for this organization URL",
       "type": "array",
       "items": {
-        "type": "string"
+        "description": "UUID of the organization category",
+        "$ref": "../../common/schemas/uuid.json"
       }
     },
     "notes": {


### PR DESCRIPTION
## Purpose
[MODORG-34](https://folio-org.atlassian.net/browse/MODORG-34) - json schema for categories defines type string but folio actually requires UUID

## Approach
Updated the schemas to enforce a UUID type.

[mod-organizations-storage PR](https://github.com/folio-org/mod-organizations-storage/pull/134) (will have to be updated when this PR is merged)

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Examples exist for all schemas
  - [ ] Descriptions exist for all schema properties
  - [ ] All schemas pass raml-cop linting
- Does this introduce breaking changes?
  - [ ] Were there any schema changes?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
