### PR TITLE
[MODORDSTOR-448] Change type of eresource.userLimit to string

### DIFF
--- a/mod-orders-storage/examples/po_line_collection.sample
+++ b/mod-orders-storage/examples/po_line_collection.sample
@@ -71,7 +71,7 @@
           },
           "materialType": "f7e72403-2a13-43a4-a069-aaabe6c9dea8",
           "trial": false,
-          "userLimit": 10,
+          "userLimit": "10",
           "resourceUrl": "https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf"
         },
         "fundDistribution": [

--- a/mod-orders-storage/examples/po_line_get.sample
+++ b/mod-orders-storage/examples/po_line_get.sample
@@ -72,7 +72,7 @@
     },
     "materialType": "4920caaf-871f-4f08-9bd5-b897203fd7fb",
     "trial": false,
-    "userLimit": 10,
+    "userLimit": "10",
     "resourceUrl": "https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf"
   },
   "fundDistribution": [

--- a/mod-orders-storage/schemas/eresource.json
+++ b/mod-orders-storage/schemas/eresource.json
@@ -34,7 +34,7 @@
     },
     "userLimit": {
       "description": "the concurrent user-limit",
-      "type": "integer"
+      "type": "string"
     },
     "accessProvider": {
       "description": "UUID of the access provider",

--- a/mod-orders/examples/composite_po_line.sample
+++ b/mod-orders/examples/composite_po_line.sample
@@ -69,7 +69,7 @@
     "createInventory": "Instance, Holding",
     "trial": false,
     "expectedActivation": "2018-10-09T00:00:00.000Z",
-    "userLimit": 10,
+    "userLimit": "10",
     "accessProvider": "ba3f3d45-247d-41f6-8dc9-6488adcad329",
     "license": {
       "code": "Code 1",


### PR DESCRIPTION
## Purpose
[MODORDSTOR-448](https://folio-org.atlassian.net/browse/MODORDSTOR-448) - Make user limit as string field & apply migration

## Approach
Changed the type and updated examples.

## Related PRs (will update with links later)
- mod-orders-storage
- mod-orders
- mod-gobi

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Examples exist for all schemas
  - [ ] Descriptions exist for all schema properties
  - [ ] All schemas pass raml-cop linting
- Does this introduce breaking changes?
  - [ ] Were there any schema changes?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
