### PR TITLE
[MODMO-6] Implement endpoint for storing Mosaic configuration options

### DIFF
--- a/mod-mosaic/examples/mosaic_configuration.sample
+++ b/mod-mosaic/examples/mosaic_configuration.sample
@@ -1,0 +1,10 @@
+{
+  "id": "74d46327-a8d6-4a4a-996a-6cd37a8071b6",
+  "defaultTemplateId": "fab26c73-0916-42aa-89b3-480d32b5fbfc",
+  "metadata": {
+    "createdDate": "2025-04-17T14:19:40.199+00:00",
+    "createdByUserId": "18214507-b7a2-492d-aa63-7389742c7209",
+    "updatedDate": "2025-04-17T14:19:40.199+00:00",
+    "updatedByUserId": "18214507-b7a2-492d-aa63-7389742c7209"
+  }
+}

--- a/mod-mosaic/schemas/mosaic_configuration.json
+++ b/mod-mosaic/schemas/mosaic_configuration.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Mosaic Configuration",
+  "type": "object",
+  "javaName": "MosaicConfiguration",
+  "properties": {
+    "id": {
+      "description": "UUID of the configuration",
+      "$ref": "../../common/schemas/uuid.json"
+    },
+    "defaultTemplateId": {
+      "description": "UUID of the default order template",
+      "$ref": "../../common/schemas/uuid.json"
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "defaultTemplateId"
+  ]
+}

--- a/mod-mosaic/schemas/mosaic_configuration.json
+++ b/mod-mosaic/schemas/mosaic_configuration.json
@@ -11,6 +11,11 @@
     "defaultTemplateId": {
       "description": "UUID of the default order template",
       "$ref": "../../common/schemas/uuid.json"
+    },
+    "metadata": {
+      "type": "object",
+      "$ref": "../../../raml-util/schemas/metadata.schema",
+      "readonly": true
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
## Purpose
[[MODMO-6] Implement endpoint for storing Mosaic configuration options](https://folio-org.atlassian.net/browse/MODMO-6)

## Approach
- Add a new model for mosaic configuration