### PR TITLE
[MODMO-15]. Implement additional mapping functionality for Mosaic orders

### DIFF
--- a/mod-mosaic/examples/mosaic_order.sample
+++ b/mod-mosaic/examples/mosaic_order.sample
@@ -35,7 +35,6 @@
       "refNumberType": "Vendor internal number"
     }
   ],
-  "listUnitPrice": 89.99,
   "listUnitPriceElectronic": 79.99,
   "currency": "USD",
   "quantityPhysical": 3,
@@ -62,9 +61,9 @@
   "shipTo": "70c42f32-d207-4c7a-9be9-7bdfa8c45d48",
   "vendor": "e0fb5df2-cdf1-11e8-a8d5-f2801f1b9fd1",
   "workflowStatus": "Pending",
-  "materialSupplier": "19bb3a90-7a45-4692-8b4d-5fe6b5b36c22",
   "accessProvider": "63183e47-8b36-410d-8c2a-e50c07175b3d",
-  "format": "P/E Mix",
+  "checkinItems": true,
+  "createInventory": "Instance, Holding"
   "customFields": {
     "externalOrderNumber": "Handle with care"
   }

--- a/mod-mosaic/examples/mosaic_order.sample
+++ b/mod-mosaic/examples/mosaic_order.sample
@@ -37,13 +37,12 @@
   ],
   "listUnitPriceElectronic": 79.99,
   "currency": "USD",
-  "quantityPhysical": 3,
   "quantityElectronic": 1,
   "locations": [
     {
       "locationId": "7d9a1c91-eb4f-4e08-94c6-2cb31c8f9067",
-      "quantity": 4,
-      "quantityPhysical": 3,
+      "quantity": 1,
+      "quantityPhysical": 0,
       "quantityElectronic": 1
     }
   ],

--- a/mod-mosaic/examples/mosaic_order.sample
+++ b/mod-mosaic/examples/mosaic_order.sample
@@ -72,6 +72,7 @@
     "accessProvider": "63183e47-8b36-410d-8c2a-e50c07175b3d",
     "userLimit": "10"
   },
+  "checkinItems": false,
   "customFields": {
     "externalOrderNumber": "Handle with care"
   }

--- a/mod-mosaic/examples/mosaic_order.sample
+++ b/mod-mosaic/examples/mosaic_order.sample
@@ -17,7 +17,6 @@
     ],
     "receivingNote": "Please check for damage upon receipt"
   },
-  "userLimit": "10",
   "requesterName": "Dr. Michael Brown",
   "selectorName": "Alice Johnson",
   "notes": [
@@ -35,14 +34,16 @@
       "refNumberType": "Vendor internal number"
     }
   ],
+  "listUnitPrice": 89.99,
   "listUnitPriceElectronic": 79.99,
   "currency": "USD",
+  "quantityPhysical": 3,
   "quantityElectronic": 1,
   "locations": [
     {
       "locationId": "7d9a1c91-eb4f-4e08-94c6-2cb31c8f9067",
-      "quantity": 1,
-      "quantityPhysical": 0,
+      "quantity": 4,
+      "quantityPhysical": 3,
       "quantityElectronic": 1
     }
   ],
@@ -54,15 +55,23 @@
       "distributionType": "percentage"
     }
   ],
-  "materialTypeId": "d9985a0f-665e-421c-b3e7-4a6e5e8f3ce1",
   "acquisitionMethod": "73d14bc5-d131-48c6-b380-f8e62f63c8f3",
   "billTo": "5b8e1e9f-2788-4e69-a368-5cdb7d58c5b6",
   "shipTo": "70c42f32-d207-4c7a-9be9-7bdfa8c45d48",
   "vendor": "e0fb5df2-cdf1-11e8-a8d5-f2801f1b9fd1",
   "workflowStatus": "Pending",
-  "accessProvider": "63183e47-8b36-410d-8c2a-e50c07175b3d",
-  "checkinItems": true,
-  "createInventory": "Instance, Holding"
+  "format": "P/E Mix",
+  "physical": {
+    "createInventory": "Instance, Holding, Item",
+    "materialType": "d9985a0f-665e-421c-b3e7-4a6e5e8f3ce1",
+    "materialSupplier": "19bb3a90-7a45-4692-8b4d-5fe6b5b36c22"
+  },
+  "eresource": {
+    "createInventory": "Instance, Holding",
+    "materialType": "d9985a0f-665e-421c-b3e7-4a6e5e8f3ce1",
+    "accessProvider": "63183e47-8b36-410d-8c2a-e50c07175b3d",
+    "userLimit": "10"
+  },
   "customFields": {
     "externalOrderNumber": "Handle with care"
   }

--- a/mod-mosaic/examples/mosaic_order_request.sample
+++ b/mod-mosaic/examples/mosaic_order_request.sample
@@ -39,13 +39,12 @@
     ],
     "listUnitPriceElectronic": 79.99,
     "currency": "USD",
-    "quantityPhysical": 3,
     "quantityElectronic": 1,
     "locations": [
       {
         "locationId": "7d9a1c91-eb4f-4e08-94c6-2cb31c8f9067",
-        "quantity": 4,
-        "quantityPhysical": 3,
+        "quantity": 1,
+        "quantityPhysical": 0,
         "quantityElectronic": 1
       }
     ],

--- a/mod-mosaic/examples/mosaic_order_request.sample
+++ b/mod-mosaic/examples/mosaic_order_request.sample
@@ -74,6 +74,7 @@
       "accessProvider": "63183e47-8b36-410d-8c2a-e50c07175b3d",
       "userLimit": "10"
     },
+    "checkinItems": false,
     "customFields": {
       "externalOrderNumber": "Handle with care"
     }

--- a/mod-mosaic/examples/mosaic_order_request.sample
+++ b/mod-mosaic/examples/mosaic_order_request.sample
@@ -19,7 +19,6 @@
       ],
       "receivingNote": "Please check for damage upon receipt"
     },
-    "userLimit": "10",
     "requesterName": "Dr. Michael Brown",
     "selectorName": "Alice Johnson",
     "notes": [
@@ -37,14 +36,16 @@
         "refNumberType": "Vendor internal number"
       }
     ],
+    "listUnitPrice": 89.99,
     "listUnitPriceElectronic": 79.99,
     "currency": "USD",
+    "quantityPhysical": 3,
     "quantityElectronic": 1,
     "locations": [
       {
         "locationId": "7d9a1c91-eb4f-4e08-94c6-2cb31c8f9067",
-        "quantity": 1,
-        "quantityPhysical": 0,
+        "quantity": 4,
+        "quantityPhysical": 3,
         "quantityElectronic": 1
       }
     ],
@@ -56,15 +57,23 @@
         "distributionType": "percentage"
       }
     ],
-    "materialTypeId": "d9985a0f-665e-421c-b3e7-4a6e5e8f3ce1",
     "acquisitionMethod": "73d14bc5-d131-48c6-b380-f8e62f63c8f3",
     "billTo": "5b8e1e9f-2788-4e69-a368-5cdb7d58c5b6",
     "shipTo": "70c42f32-d207-4c7a-9be9-7bdfa8c45d48",
     "vendor": "e0fb5df2-cdf1-11e8-a8d5-f2801f1b9fd1",
     "workflowStatus": "Pending",
-    "accessProvider": "63183e47-8b36-410d-8c2a-e50c07175b3d",
-    "checkinItems": true,
-    "createInventory": "Instance, Holding"
+    "format": "P/E Mix",
+    "physical": {
+      "createInventory": "Instance, Holding, Item",
+      "materialType": "d9985a0f-665e-421c-b3e7-4a6e5e8f3ce1",
+      "materialSupplier": "19bb3a90-7a45-4692-8b4d-5fe6b5b36c22"
+    },
+    "eresource": {
+      "createInventory": "Instance, Holding",
+      "materialType": "d9985a0f-665e-421c-b3e7-4a6e5e8f3ce1",
+      "accessProvider": "63183e47-8b36-410d-8c2a-e50c07175b3d",
+      "userLimit": "10"
+    },
     "customFields": {
       "externalOrderNumber": "Handle with care"
     }

--- a/mod-mosaic/examples/mosaic_order_request.sample
+++ b/mod-mosaic/examples/mosaic_order_request.sample
@@ -37,7 +37,6 @@
         "refNumberType": "Vendor internal number"
       }
     ],
-    "listUnitPrice": 89.99,
     "listUnitPriceElectronic": 79.99,
     "currency": "USD",
     "quantityPhysical": 3,
@@ -64,9 +63,9 @@
     "shipTo": "70c42f32-d207-4c7a-9be9-7bdfa8c45d48",
     "vendor": "e0fb5df2-cdf1-11e8-a8d5-f2801f1b9fd1",
     "workflowStatus": "Pending",
-    "materialSupplier": "19bb3a90-7a45-4692-8b4d-5fe6b5b36c22",
     "accessProvider": "63183e47-8b36-410d-8c2a-e50c07175b3d",
-    "format": "P/E Mix",
+    "checkinItems": true,
+    "createInventory": "Instance, Holding"
     "customFields": {
       "externalOrderNumber": "Handle with care"
     }

--- a/mod-mosaic/schemas/mosaic_order.json
+++ b/mod-mosaic/schemas/mosaic_order.json
@@ -34,10 +34,6 @@
       "type": "object",
       "$ref": "../../mod-orders-storage/schemas/details.json"
     },
-    "userLimit": {
-      "description": "the concurrent user-limit",
-      "type": "string"
-    },
     "requesterName": {
       "description": "who requested this purchase order line",
       "type": "string"
@@ -106,10 +102,6 @@
         "$ref": "../../mod-orders-storage/schemas/fund_distribution.json"
       }
     },
-    "materialTypeId": {
-      "description": "material type of the material",
-      "$ref": "../../common/schemas/uuid.json"
-    },
     "acquisitionMethod": {
       "description": "UUID of the acquisition method for this purchase order line",
       "$ref": "../../common/schemas/uuid.json"
@@ -138,18 +130,20 @@
       "type": "string",
       "$ref": "../../mod-orders-storage/schemas/workflow_status.json"
     },
-    "materialSupplier": {
-      "description": "UUID for the material supplier",
-      "$ref": "../../common/schemas/uuid.json"
-    },
-    "accessProvider": {
-      "description": "UUID for the access provider",
-      "$ref": "../../common/schemas/uuid.json"
-    },
     "format": {
       "description": "Order format (Physical Resource, Electronic Resource, P/E mix, Other)",
       "type": "string",
       "$ref": "../../mod-orders-storage/schemas/order_format.json"
+    },
+    "physical": {
+      "description": "details of this purchase order line relating to physical materials",
+      "type": "object",
+      "$ref": "../../mod-orders-storage/schemas/physical.json"
+    },
+    "eresource": {
+      "description": "eresource-related details of this purchase order line",
+      "type": "object",
+      "$ref": "../../mod-orders-storage/schemas/eresource.json"
     },
     "customFields": {
       "description": "Custom fields for the order",

--- a/mod-mosaic/schemas/mosaic_order.json
+++ b/mod-mosaic/schemas/mosaic_order.json
@@ -34,6 +34,10 @@
       "type": "object",
       "$ref": "../../mod-orders-storage/schemas/details.json"
     },
+    "userLimit": {
+      "description": "the concurrent user-limit",
+      "type": "string"
+    },
     "requesterName": {
       "description": "who requested this purchase order line",
       "type": "string"
@@ -62,10 +66,6 @@
       "description": "Collection of reference number items",
       "$ref": "../../common/schemas/reference_numbers.json"
     },
-    "listUnitPrice": {
-      "description": "The per-item list price for physical or resources of 'Other' order format",
-      "type": "number"
-    },
     "listUnitPriceElectronic": {
       "description": "The e-resource per-item list price",
       "type": "number"
@@ -73,10 +73,6 @@
     "currency": {
       "description": "An ISO currency code",
       "type": "string"
-    },
-    "quantityPhysical": {
-      "description": "Quantity of physical items or resources of 'Other' order format in this purchase order line",
-      "type": "integer"
     },
     "quantityElectronic": {
       "description": "Quantity of electronic items in this purchase order line",
@@ -101,6 +97,10 @@
         "type": "object",
         "$ref": "../../mod-orders-storage/schemas/fund_distribution.json"
       }
+    },
+    "materialTypeId": {
+      "description": "material type of the material",
+      "$ref": "../../common/schemas/uuid.json"
     },
     "acquisitionMethod": {
       "description": "UUID of the acquisition method for this purchase order line",
@@ -130,20 +130,24 @@
       "type": "string",
       "$ref": "../../mod-orders-storage/schemas/workflow_status.json"
     },
-    "format": {
-      "description": "Order format (Physical Resource, Electronic Resource, P/E mix, Other)",
+    "accessProvider": {
+      "description": "UUID for the access provider",
+      "$ref": "../../common/schemas/uuid.json"
+    },
+    "checkinItems": {
+      "description": "if true this will toggle the Check-in workflow for details associated with this PO line",
+      "type": "boolean",
+      "default": false
+    },
+    "createInventory": {
+      "description": "Shows what inventory objects need to be created for electronic resource",
       "type": "string",
-      "$ref": "../../mod-orders-storage/schemas/order_format.json"
-    },
-    "physical": {
-      "description": "details of this purchase order line relating to physical materials",
-      "type": "object",
-      "$ref": "../../mod-orders-storage/schemas/physical.json"
-    },
-    "eresource": {
-      "description": "eresource-related details of this purchase order line",
-      "type": "object",
-      "$ref": "../../mod-orders-storage/schemas/eresource.json"
+      "enum": [
+        "Instance, Holding, Item",
+        "Instance, Holding",
+        "Instance",
+        "None"
+      ]
     },
     "customFields": {
       "description": "Custom fields for the order",

--- a/mod-mosaic/schemas/mosaic_order.json
+++ b/mod-mosaic/schemas/mosaic_order.json
@@ -34,10 +34,6 @@
       "type": "object",
       "$ref": "../../mod-orders-storage/schemas/details.json"
     },
-    "userLimit": {
-      "description": "the concurrent user-limit",
-      "type": "string"
-    },
     "requesterName": {
       "description": "who requested this purchase order line",
       "type": "string"
@@ -66,6 +62,10 @@
       "description": "Collection of reference number items",
       "$ref": "../../common/schemas/reference_numbers.json"
     },
+    "listUnitPrice": {
+      "description": "The per-item list price for physical or resources of 'Other' order format",
+      "type": "number"
+    },
     "listUnitPriceElectronic": {
       "description": "The e-resource per-item list price",
       "type": "number"
@@ -73,6 +73,10 @@
     "currency": {
       "description": "An ISO currency code",
       "type": "string"
+    },
+    "quantityPhysical": {
+      "description": "Quantity of physical items or resources of 'Other' order format in this purchase order line",
+      "type": "integer"
     },
     "quantityElectronic": {
       "description": "Quantity of electronic items in this purchase order line",
@@ -97,10 +101,6 @@
         "type": "object",
         "$ref": "../../mod-orders-storage/schemas/fund_distribution.json"
       }
-    },
-    "materialTypeId": {
-      "description": "material type of the material",
-      "$ref": "../../common/schemas/uuid.json"
     },
     "acquisitionMethod": {
       "description": "UUID of the acquisition method for this purchase order line",
@@ -130,24 +130,20 @@
       "type": "string",
       "$ref": "../../mod-orders-storage/schemas/workflow_status.json"
     },
-    "accessProvider": {
-      "description": "UUID for the access provider",
-      "$ref": "../../common/schemas/uuid.json"
-    },
-    "checkinItems": {
-      "description": "if true this will toggle the Check-in workflow for details associated with this PO line",
-      "type": "boolean",
-      "default": false
-    },
-    "createInventory": {
-      "description": "Shows what inventory objects need to be created for electronic resource",
+    "format": {
+      "description": "Order format (Physical Resource, Electronic Resource, P/E mix, Other)",
       "type": "string",
-      "enum": [
-        "Instance, Holding, Item",
-        "Instance, Holding",
-        "Instance",
-        "None"
-      ]
+      "$ref": "../../mod-orders-storage/schemas/order_format.json"
+    },
+    "physical": {
+      "description": "details of this purchase order line relating to physical materials",
+      "type": "object",
+      "$ref": "../../mod-orders-storage/schemas/physical.json"
+    },
+    "eresource": {
+      "description": "eresource-related details of this purchase order line",
+      "type": "object",
+      "$ref": "../../mod-orders-storage/schemas/eresource.json"
     },
     "customFields": {
       "description": "Custom fields for the order",

--- a/mod-mosaic/schemas/mosaic_order.json
+++ b/mod-mosaic/schemas/mosaic_order.json
@@ -145,6 +145,11 @@
       "type": "object",
       "$ref": "../../mod-orders-storage/schemas/eresource.json"
     },
+    "checkinItems": {
+      "description": "if true this will toggle the Check-in workflow for details associated with this PO line",
+      "type": "boolean",
+      "default": false
+    },
     "customFields": {
       "description": "Custom fields for the order",
       "type": "object",

--- a/mod-mosaic/schemas/mosaic_order.json
+++ b/mod-mosaic/schemas/mosaic_order.json
@@ -146,7 +146,7 @@
       "$ref": "../../mod-orders-storage/schemas/eresource.json"
     },
     "checkinItems": {
-      "description": "if true this will toggle the Check-in workflow for details associated with this PO line",
+      "description": "If true will configure the POL for the 'Independent order and receipt quantity' receiving workflow, alternatively will default to 'Synchronized order and receipt quantity'",
       "type": "boolean",
       "default": false
     },


### PR DESCRIPTION
## Purpose

- <https://folio-org.atlassian.net/browse/MODMO-15>

## Approach

- Add fields: `physical`, `eresource`, and `checkinItems`
- Remove fields: `userLimit`, `materialTypeId`, `materialSupplier` and `accessProvider`
- Update samples