### PR TITLE
MODMO-15. Remove default option from mosaic request

### DIFF
--- a/mod-mosaic/schemas/mosaic_order.json
+++ b/mod-mosaic/schemas/mosaic_order.json
@@ -155,8 +155,7 @@
     },
     "checkinItems": {
       "description": "If true will configure the POL for the 'Independent order and receipt quantity' receiving workflow, alternatively will default to 'Synchronized order and receipt quantity'",
-      "type": "boolean",
-      "default": false
+      "type": "boolean"
     },
     "customFields": {
       "description": "Custom fields for the order",


### PR DESCRIPTION
## Purpose
https://folio-org.atlassian.net/browse/MODMO-15
Currently default value 'false' always override value from order teamplate, even if it not populated in request, so need to delete default values to resolve this issue