### PR TITLE
[EDGORDERS-101]. Change mosaic order schema to account for PO/POL custom fields

### DIFF
--- a/mod-mosaic/examples/mosaic_custom_fields.sample
+++ b/mod-mosaic/examples/mosaic_custom_fields.sample
@@ -1,0 +1,12 @@
+[
+  {
+    "refId": "externalOrderNumber",
+    "entityType": "purchase_order",
+    "value": "Handle with care"
+  },
+  {
+    "refId": "membership",
+    "entityType": "po_line",
+    "value": "opt_1"
+  }
+]

--- a/mod-mosaic/examples/mosaic_order_request.sample
+++ b/mod-mosaic/examples/mosaic_order_request.sample
@@ -77,8 +77,17 @@
       "userLimit": "10"
     },
     "checkinItems": false,
-    "customFields": {
-      "externalOrderNumber": "Handle with care"
-    }
+    "customFields": [
+      {
+        "refId": "externalOrderNumber",
+        "entityType": "purchase_order",
+        "value": "Handle with care"
+      },
+      {
+        "refId": "membership",
+        "entityType": "po_line",
+        "value": "opt_1"
+      }
+    ]
   }
 }

--- a/mod-mosaic/schemas/mosaic_custom_fields.json
+++ b/mod-mosaic/schemas/mosaic_custom_fields.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Mosaic custom fields record",
+  "additionalProperties": true,
+  "properties": {
+    "refId": {
+      "type": "string",
+      "description": "The reference id of the custom field",
+      "example": "department_1"
+    },
+    "entityType": {
+      "type": "string",
+      "description": "The entity type, the custom field is assigned to",
+      "enum": [
+        "purchase_order",
+        "po_line"
+      ]
+    },
+    "value": {
+      "type": "string",
+      "description": "The value of the custom field",
+      "example": "Test"
+    }
+  },
+  "required": [
+    "refId",
+    "entityType",
+    "value"
+  ]
+}

--- a/mod-mosaic/schemas/mosaic_order.json
+++ b/mod-mosaic/schemas/mosaic_order.json
@@ -158,9 +158,14 @@
       "type": "boolean"
     },
     "customFields": {
-      "description": "Custom fields for the order",
-      "type": "object",
-      "$ref": "../../common/schemas/custom_fields.json"
+      "description": "Mosaic custom fields for either the PO or POL",
+      "id": "customFields",
+      "type": "array",
+      "items": {
+        "description": "A Mosaic custom fields record",
+        "type": "object",
+        "$ref": "mosaic_custom_fields.json"
+      }
     },
     "metadata": {
       "type": "object",


### PR DESCRIPTION
## Purpose

- <https://folio-org.atlassian.net/browse/EDGORDERS-101>

## Approach

- Expand the mosaic order schema to accept an array of objects comprised of `refId`, `entityType` and `value`
- The `entityType` field on the object will be used to determine if the custom field is for the PO or POL 