### PR TITLE
[EDGORDERS-101-3]. Allows passing value as an additional field of object type

### DIFF
--- a/mod-mosaic/schemas/mosaic_custom_fields.json
+++ b/mod-mosaic/schemas/mosaic_custom_fields.json
@@ -16,11 +16,6 @@
         "purchase_order",
         "po_line"
       ]
-    },
-    "value": {
-      "type": "string",
-      "description": "The value of the custom field",
-      "example": "Test"
     }
   },
   "required": [


### PR DESCRIPTION
## Purpose

- <https://folio-org.atlassian.net/browse/EDGORDERS-101>

## Approach

- Remove value field from the schema so that it can be pass as an additional field with any type