### PR TITLE
MODFISTO-526. Fix issue with missing metadata

### DIFF
--- a/mod-finance/schemas/exchange_rate_source.json
+++ b/mod-finance/schemas/exchange_rate_source.json
@@ -36,6 +36,12 @@
       "description": "Refresh interval specified in seconds",
       "type": "integer",
       "default": 86400
+    },
+    "metadata": {
+      "description": "Metadata about creation and changes to record, provided by the server (client should not provide)",
+      "type": "object",
+      "$ref": "../../../raml-util/schemas/metadata.schema",
+      "readonly": true
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
## Purpose

- <https://folio-org.atlassian.net/browse/MODFISTO-526>

## Approach

- Add missing metadata field to the schema so that it begins to be populated by the incoming requests
- Tested by recompiling mod-finance-storage and reinstalling the module locally with this command:

```bash
curl --location 'http://localhost:36014/_/tenant' \
--header 'x-okapi-tenant: diku' \
--header 'x-okapi-token:  ${TOKEN}' \
--header 'Content-Type: application/json' \
--data '{
    "module_to": "mod-finance-storage:8.9.0-SNAPSHOT.409",
    "parameters": []
}'
```

- The result in DBeaver:

![image](https://github.com/user-attachments/assets/42be36f6-4a4a-48ff-86b5-be6ba5563395)

> Metadata is now being added on any CRUD action
