### PR TITLE
[MODINVOICE-611]. Fix "Calculated Total Amount (Exchange)" calculation in invoice for Treasure and Currencyapi providers

### DIFF
--- a/mod-finance/examples/exchange_rate_calculations.sample
+++ b/mod-finance/examples/exchange_rate_calculations.sample
@@ -4,6 +4,7 @@
       "from": "USD",
       "to": "EUR",
       "amount": 1000,
+      "manual": true,
       "rate": 0.85
     },
     {

--- a/mod-finance/schemas/exchange_rate_calculations.json
+++ b/mod-finance/schemas/exchange_rate_calculations.json
@@ -26,6 +26,11 @@
             "description": "Custom exchange rate to use for the calculation",
             "type": "number"
           },
+          "manual": {
+            "description": "Is the exchange rate manually set?",
+            "default": false,
+            "type": "boolean"
+          },
           "calculation": {
             "description": "Calculated exchange rate value",
             "type": "number"


### PR DESCRIPTION
## Purpose

- <https://folio-org.atlassian.net/browse/MODINVOICE-611>

## Approach

- Add a new `manual` field into the calculation payload to allow the Batch Exchange Rate API to override the provider value