### PR TITLE
[MODORDSTOR-486] Add FQM entity type schema annotations

### DIFF
--- a/mod-orders-storage/schemas/contributor.json
+++ b/mod-orders-storage/schemas/contributor.json
@@ -10,7 +10,8 @@
     "contributorNameTypeId": {
       "description": "UUID of the contributor type",
       "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+      "pattern": "^[a-f0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "x-fqm-visibility": "hidden"
     }
   },
   "additionalProperties": false,

--- a/mod-orders-storage/schemas/piece.json
+++ b/mod-orders-storage/schemas/piece.json
@@ -6,135 +6,182 @@
   "properties": {
     "id": {
       "description": "UUID of this piece record",
-      "$ref": "../../common/schemas/uuid.json"
+      "$ref": "../../common/schemas/uuid.json",
+      "x-fqm-essential": true
     },
-      "displaySummary": {
+    "displaySummary": {
       "description": "Display summary information",
-      "type": "string"
+      "type": "string",
+      "x-fqm-essential": true,
+      "x-fqm-visible-by-default": true
     },
-      "comment": {
+    "comment": {
       "description": "Free form commentary",
-      "type": "string"
+      "type": "string",
+      "x-fqm-essential": true
     },
     "format": {
       "description": "The format of the piece",
       "type": "string",
-      "$ref": "piece_format.json"
+      "$ref": "piece_format.json",
+      "x-fqm-essential": true,
+      "x-fqm-visible-by-default": true
     },
     "itemId": {
       "description": "UUID of the associated item record",
-      "$ref": "../../common/schemas/uuid.json"
+      "$ref": "../../common/schemas/uuid.json",
+      "x-fqm-essential": true,
+      "x-fqm-visibility": "hidden"
     },
     "bindItemId": {
       "description": "UUID of the associated bind item record",
-      "$ref": "../../common/schemas/uuid.json"
+      "$ref": "../../common/schemas/uuid.json",
+      "x-fqm-essential": true,
+      "x-fqm-visibility": "hidden"
     },
     "bindItemTenantId": {
       "description": "Bind item tenant for ECS-enabled clusters",
-      "type": "string"
+      "type": "string",
+      "x-fqm-essential": true
     },
     "locationId": {
       "description": "UUID of the (inventory) location record",
-      "$ref": "../../common/schemas/uuid.json"
+      "$ref": "../../common/schemas/uuid.json",
+      "x-fqm-essential": true,
+      "x-fqm-visibility": "hidden"
     },
     "poLineId": {
       "description": "UUID of the purchase order line this record is associated with",
-      "$ref": "../../common/schemas/uuid.json"
+      "$ref": "../../common/schemas/uuid.json",
+      "x-fqm-essential": true,
+      "x-fqm-visibility": "hidden"
     },
     "titleId": {
       "description": "UUID of the title record",
-      "$ref": "../../common/schemas/uuid.json"
+      "$ref": "../../common/schemas/uuid.json",
+      "x-fqm-essential": true,
+      "x-fqm-visibility": "hidden"
     },
     "holdingId": {
       "description": "UUID of the holding record",
-      "$ref": "../../common/schemas/uuid.json"
+      "$ref": "../../common/schemas/uuid.json",
+      "x-fqm-essential": true,
+      "x-fqm-visibility": "hidden"
     },
     "receivingTenantId": {
       "description": "Receiving tenant for ECS-enabled clusters",
-      "type": "string"
+      "type": "string",
+      "x-fqm-essential": true
     },
     "displayOnHolding": {
       "description": "Whether or not receiving history should be displayed in holding record view",
       "type": "boolean",
-      "default": false
+      "default": false,
+      "x-fqm-essential": true
     },
     "displayToPublic": {
       "description": "Whether or not the piece data should display to patrons at point of receipt",
       "type": "boolean",
-      "default": false
+      "default": false,
+      "x-fqm-essential": true,
+      "x-fqm-visible-by-default": true
     },
     "sequenceNumber": {
       "description": "The sequence number of this piece to determine the order in which it appears",
       "type": "integer",
-      "minimum": 1
+      "minimum": 1,
+      "x-fqm-essential": true,
+      "x-fqm-visible-by-default": true
     },
     "enumeration": {
       "type": "string",
-      "description": "Enumeration is the descriptive information for the numbering scheme of a serial. Synchronized with inventory item."
+      "description": "Enumeration is the descriptive information for the numbering scheme of a serial. Synchronized with inventory item.",
+      "x-fqm-essential": true,
+      "x-fqm-visible-by-default": true
     },
     "chronology": {
       "type": "string",
-      "description": "Chronology is the descriptive information for the dating scheme of a serial. Synchronized with inventory item."
+      "description": "Chronology is the descriptive information for the dating scheme of a serial. Synchronized with inventory item.",
+      "x-fqm-essential": true,
+      "x-fqm-visible-by-default": true
     },
     "barcode": {
       "type": "string",
-      "description": "Barcode is the descriptive information for the barcode of a serial. Synchronized with inventory item."
+      "description": "Barcode is the descriptive information for the barcode of a serial. Synchronized with inventory item.",
+      "x-fqm-essential": true
     },
     "accessionNumber": {
       "type": "string",
-      "description": "AccessionNumber is the descriptive information for the accession number of a serial. Synchronized with inventory item."
+      "description": "AccessionNumber is the descriptive information for the accession number of a serial. Synchronized with inventory item.",
+      "x-fqm-essential": true
     },
     "callNumber": {
       "type": "string",
-      "description": "CallNumber is the descriptive information for the call number of a serial. Synchronized with inventory item."
+      "description": "CallNumber is the descriptive information for the call number of a serial. Synchronized with inventory item.",
+      "x-fqm-essential": true
     },
     "discoverySuppress": {
       "type": "boolean",
-      "description": "Records the fact that the record should not be displayed in a discovery system"
+      "description": "Records the fact that the record should not be displayed in a discovery system",
+      "x-fqm-essential": true
     },
     "copyNumber": {
       "type": "string",
-      "description": "Copy number of the piece"
+      "description": "Copy number of the piece",
+      "x-fqm-essential": true,
+      "x-fqm-visible-by-default": true
     },
     "receivingStatus": {
       "description": "The status of this piece",
-      "$ref": "receiving_status.json"
+      "$ref": "receiving_status.json",
+      "x-fqm-essential": true,
+      "x-fqm-visible-by-default": true
     },
     "supplement": {
       "description": "Whether or not this is supplementary material",
-      "type": "boolean"
+      "type": "boolean",
+      "x-fqm-essential": true
     },
     "isBound": {
       "description": "Whether or not piece has already been bound",
       "type": "boolean",
-      "default": false
+      "default": false,
+      "x-fqm-essential": true
     },
     "receiptDate": {
       "description": "Date that associated item is expected to arrive",
       "type": "string",
-      "format": "date-time"
+      "format": "date-time",
+      "x-fqm-essential": true,
+      "x-fqm-visible-by-default": true
     },
     "receivedDate": {
       "description": "The date associated item is actually received",
       "type": "string",
-      "format": "date-time"
+      "format": "date-time",
+      "x-fqm-essential": true,
+      "x-fqm-visible-by-default": true
     },
     "statusUpdatedDate": {
       "description": "Date when the status of this piece was last updated",
       "type": "string",
-      "format": "date-time"
+      "format": "date-time",
+      "x-fqm-essential": true
     },
     "claimingInterval": {
       "description": "Time interval (in days) for processing claims related to this piece",
-      "type": "integer"
+      "type": "integer",
+      "x-fqm-essential": true
     },
     "internalNote": {
       "description": "Internal note for Send Claim action",
-      "type": "string"
+      "type": "string",
+      "x-fqm-essential": true
     },
     "externalNote": {
       "description": "External note for Send Claim action to share with Vendor",
-      "type": "string"
+      "type": "string",
+      "x-fqm-essential": true
     },
     "metadata": {
       "type": "object",

--- a/mod-orders-storage/schemas/product_identifier.json
+++ b/mod-orders-storage/schemas/product_identifier.json
@@ -9,7 +9,8 @@
     },
     "productIdType": {
       "description": "The type of product identifier",
-      "$ref": "../../common/schemas/product_id_type.json"
+      "$ref": "../../common/schemas/product_id_type.json",
+      "x-fqm-visibility": "hidden"
     },
     "qualifier": {
       "description": "Information about the binding, format, volume numbers, part of a set, publisher, distributor, etc. which might be enclosed in parenthesis",

--- a/mod-orders-storage/schemas/title.json
+++ b/mod-orders-storage/schemas/title.json
@@ -5,30 +5,40 @@
   "properties": {
     "id": {
       "description": "UUID of this title",
-      "$ref": "../../common/schemas/uuid.json"
+      "$ref": "../../common/schemas/uuid.json",
+      "x-fqm-essential": true
     },
     "expectedReceiptDate": {
       "description": "Vendor agreed date prior to the Receipt Due date item is expected to be received by",
       "type": "string",
-      "format": "date-time"
+      "format": "date-time",
+      "x-fqm-essential": true,
+      "x-fqm-visible-by-default": true
     },
     "title": {
       "description": "The title name",
-      "type": "string"
+      "type": "string",
+      "x-fqm-essential": true,
+      "x-fqm-visible-by-default": true
     },
     "poLineId": {
       "description": "UUID of the purchase order line this Title is associated with",
-      "$ref": "../../common/schemas/uuid.json"
+      "$ref": "../../common/schemas/uuid.json",
+      "x-fqm-essential": true,
+      "x-fqm-visibility": "hidden"
     },
     "instanceId": {
       "description": "UUID of the instance associated with this Title",
-      "$ref": "../../common/schemas/uuid.json"
+      "$ref": "../../common/schemas/uuid.json",
+      "x-fqm-essential": true,
+      "x-fqm-visibility": "hidden"
     },
     "nextSequenceNumber": {
       "description": "The next sequence number to be used for the created Piece records",
       "type": "integer",
       "minimum": 1,
-      "default": 1
+      "default": 1,
+      "x-fqm-essential": true
     },
     "productIds": {
       "description": "List of product identifiers",
@@ -36,83 +46,104 @@
       "type": "array",
       "items": {
         "$ref": "product_identifier.json"
-      }
+      },
+      "x-fqm-essential": true
     },
     "contributors": {
       "description": "List of contributors to the material",
       "id": "contributors",
       "type": "array",
       "items": {
-       "type": "object",
+        "type": "object",
         "$ref": "contributor.json"
-      }
+      },
+      "x-fqm-essential": true
     },
     "publisher": {
       "description": "Publisher of the material",
-      "type": "string"
+      "type": "string",
+      "x-fqm-essential": true
     },
     "edition": {
       "description": "Edition of the material",
-      "type": "string"
+      "type": "string",
+      "x-fqm-essential": true
     },
     "packageName": {
       "description": "The name of the package",
-      "type": "string"
+      "type": "string",
+      "x-fqm-essential": true,
+      "x-fqm-visible-by-default": true
     },
     "poLineNumber": {
       "description": "The number of the POL identified by poLineId",
       "type": "string",
-      "pattern": "^[a-zA-Z0-9]{1,16}-[0-9]{1,3}$"
+      "pattern": "^[a-zA-Z0-9]{1,16}-[0-9]{1,3}$",
+      "x-fqm-essential": true,
+      "x-fqm-visible-by-default": true
     },
     "publishedDate": {
       "description": "Year of the material's publication",
-      "type": "string"
+      "type": "string",
+      "x-fqm-essential": true
     },
     "receivingNote": {
       "description": "Receiving note of the POL identified by poLineId",
-      "type": "string"
+      "type": "string",
+      "x-fqm-essential": true,
+      "x-fqm-visible-by-default": true
     },
     "subscriptionFrom": {
       "description": "The start date of the subscription",
       "type": "string",
-      "format": "date-time"
+      "format": "date-time",
+      "x-fqm-essential": true
     },
     "subscriptionTo": {
       "description": "The end date of the subscription",
       "type": "string",
-      "format": "date-time"
+      "format": "date-time",
+      "x-fqm-essential": true
     },
     "subscriptionInterval": {
       "description": "The subscription interval in days",
-      "type": "integer"
+      "type": "integer",
+      "x-fqm-essential": true
     },
     "claimingActive": {
       "description": "Indicates if there is an active claim or dispute",
       "type": "boolean",
-      "default": false
+      "default": false,
+      "x-fqm-essential": true
     },
     "claimingInterval": {
       "description": "Specifies the time interval, in days, within which claims or disputes must be initiated",
-      "type": "integer"
+      "type": "integer",
+      "x-fqm-essential": true
     },
     "isAcknowledged": {
       "description": "Flag for acknowledge receiving note",
       "type": "boolean",
-      "default": false
+      "default": false,
+      "x-fqm-essential": true
     },
     "bindItemIds": {
       "description": "Item ids which bound to this title for independent receiving workflow",
       "type": "array",
       "items": {
         "$ref": "../../common/schemas/uuid.json"
-      }
+      },
+      "x-fqm-essential": true,
+      "x-fqm-visibility": "hidden"
     },
     "acqUnitIds": {
       "description": "acquisition unit ids associated with this title",
       "type": "array",
       "items": {
         "$ref": "../../common/schemas/uuid.json"
-      }
+      },
+      "x-fqm-essential": true,
+      "x-fqm-visibility": "hidden"
     },
     "metadata": {
       "type": "object",


### PR DESCRIPTION
# [Jira MODORDSTOR-486](https://folio-org.atlassian.net/browse/MODORDSTOR-486)

## Purpose
The FOLIO Query Machine would like to report on data from `mod-orders-storage` (currently, `pieces` and `titles`). To do this, Entity Types will be generated based on this schema information, and, to ensure data are displayed properly to users, we must add annotations to these schemas to control things like default field visibility. For more information on FQM and the entity type generation process, see [this article](https://github.com/folio-org/fqm-tools/blob/69aabb6cbc3f4a0a44383acbf011d070cac8c047/docs/generation/01-introduction.md).

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Examples exist for all schemas (N/A)
  - [x] Descriptions exist for all schema properties (N/A)
  - [x] All schemas pass raml-cop linting
- Does this introduce breaking changes?
  - [x] Were there any schema changes? **(Not that matter to applications besides FQM)**
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
  - `mod-fqm-manager` via an existing automated flow, as described in [fqm-tools](https://github.com/folio-org/fqm-tools/blob/69aabb6cbc3f4a0a44383acbf011d070cac8c047/docs/generation/01-introduction.md)
  - `mod-orders-storage` will be synced to this version of `acq-models` after merge, with additional supporting files added. This will be done under the same ticket
