### PR TITLE
[MODINVOICE-647] Removed readonly attribute for next pol/il number

### DIFF
--- a/mod-invoice-storage/schemas/invoice.json
+++ b/mod-invoice-storage/schemas/invoice.json
@@ -194,8 +194,7 @@
     },
     "nextInvoiceLineNumber": {
       "description": "Number that will be used next time an invoice line is created",
-      "type": "integer",
-      "readonly": true
+      "type": "integer"
     },
     "metadata": {
       "type": "object",

--- a/mod-orders-storage/schemas/purchase_order.json
+++ b/mod-orders-storage/schemas/purchase_order.json
@@ -113,8 +113,7 @@
     },
     "nextPolNumber": {
       "description": "Number that will be used next time a purchase order line is created",
-      "type": "integer",
-      "readonly": true
+      "type": "integer"
     },
     "tags": {
       "type": "object",


### PR DESCRIPTION
## Purpose
[MODINVOICE-647](https://folio-org.atlassian.net/browse/MODINVOICE-647) - Invoice line number is reused after deletion

## Approach
Removed `readonly` attribute for next pol/il number

## Related PRs
- [mod-orders-storage](https://github.com/folio-org/mod-orders-storage/pull/623)
- [mod-invoice-storage](https://github.com/folio-org/mod-invoice-storage/pull/259)

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Examples exist for all schemas
  - [ ] Descriptions exist for all schema properties
  - [ ] All schemas pass raml-cop linting
- Does this introduce breaking changes?
  - [ ] Were there any schema changes?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
