### PR TITLE
[MODINVOICE-648]. "Sub total" and "Calculated total amount" missing from Invoice version history

### DIFF
--- a/mod-invoice-storage/schemas/invoice.json
+++ b/mod-invoice-storage/schemas/invoice.json
@@ -130,13 +130,11 @@
     },
     "subTotal": {
       "description": "Invoice amount before adjustments are applied. This is sum of all subTotal amounts of the corresponding invoice lines. This amount is always calculated by system.",
-      "type": "number",
-      "readonly": true
+      "type": "number"
     },
     "total": {
       "description": "The total amount is calculated \"on the fly\" of this invoice which is sum of subTotal and adjustmentsTotal. Must be the same with existed \"lockTotal\", when approve invoice.",
-      "type": "number",
-      "readonly": true
+      "type": "number"
     },
     "vendorInvoiceNo": {
       "description": "This is the number from the vendor's invoice, which is different from the folioInvoiceNo",


### PR DESCRIPTION
## Purpose

- <https://folio-org.atlassian.net/browse/MODINVOICE-648>

## Approach

- Remove `"readonly": true` property on both `subTotal` and `total`, to allow these fields to be serializable