### PR TITLE
[MODORDSTOR-516] Add original snapshot field to order, order line and piece

### DIFF
--- a/mod-orders-storage/schemas/order_audit_event.json
+++ b/mod-orders-storage/schemas/order_audit_event.json
@@ -33,7 +33,12 @@
     "orderSnapshot": {
       "description": "Full snapshot of the order",
       "type": "object",
-      "$ref": "purchase_order.json"
+      "javaType": "org.folio.rest.jaxrs.model.PurchaseOrder"
+    },
+    "originalOrderSnapshot": {
+      "description": "Full snapshot of the order before the EDIT action",
+      "type": "object",
+      "javaType": "org.folio.rest.jaxrs.model.PurchaseOrder"
     }
   },
   "additionalProperties": false

--- a/mod-orders-storage/schemas/order_line_audit_event.json
+++ b/mod-orders-storage/schemas/order_line_audit_event.json
@@ -37,7 +37,12 @@
     "orderLineSnapshot": {
       "description": "Full snapshot of the order line",
       "type": "object",
-      "$ref": "po_line.json"
+      "javaType": "org.folio.rest.jaxrs.model.PoLine"
+    },
+    "originalOrderLineSnapshot": {
+      "description": "Full snapshot of the order line before the EDIT action",
+      "type": "object",
+      "javaType": "org.folio.rest.jaxrs.model.PoLine"
     }
   },
   "additionalProperties": false

--- a/mod-orders-storage/schemas/piece_audit_event.json
+++ b/mod-orders-storage/schemas/piece_audit_event.json
@@ -33,7 +33,12 @@
     "pieceSnapshot": {
       "description": "Full snapshot of the piece",
       "type": "object",
-      "$ref": "piece.json"
+      "javaType": "org.folio.rest.jaxrs.model.Piece"
+    },
+    "originalPieceSnapshot": {
+      "description": "Full snapshot of the piece before the EDIT action",
+      "type": "object",
+      "javaType": "org.folio.rest.jaxrs.model.Piece"
     }
   },
   "additionalProperties": false


### PR DESCRIPTION
### **Purpose**
[[MODORDSTOR-516](https://folio-org.atlassian.net/browse/MODORDSTOR-516)] Add old object for EDIT audit events for PO, PO Line and Piece

### **Approach**
Add original snapshot field to order, order line and piece