### PR TITLE
[MODORDSTOR-521] Add deprecated flag to the acquisition method schema

### DIFF
--- a/mod-orders-storage/examples/acquisition_method_collection.sample
+++ b/mod-orders-storage/examples/acquisition_method_collection.sample
@@ -5,11 +5,22 @@
             "id": "73d14bc5-d131-48c6-b380-f8e62f63c8f3",
             "value": "Purchase At Vendor System",
             "source": "System",
+            "deprecated": false,
+            "metadata": {
+              "createdDate": "2018-07-19T00:00:00.000+0000",
+              "createdByUserId": "28d1057c-d137-11e8-a8d5-f2801f1b9fd1"
+            }
+          },
+          {
+            "id": "0a8a76c5-1bba-4b9a-b1b6-1f9f9c0a8f3b",
+            "value": "Evidence Based Acquisition",
+            "source": "User",
+            "deprecated": true,
             "metadata": {
               "createdDate": "2018-07-19T00:00:00.000+0000",
               "createdByUserId": "28d1057c-d137-11e8-a8d5-f2801f1b9fd1"
             }
           }
         ],
-    "totalRecords": 1
+    "totalRecords": 2
 }

--- a/mod-orders-storage/examples/acquisition_method_get.sample
+++ b/mod-orders-storage/examples/acquisition_method_get.sample
@@ -2,6 +2,7 @@
   "id": "73d14bc5-d131-48c6-b380-f8e62f63c8f3",
   "value": "Purchase At Vendor System",
   "source": "System",
+  "deprecated": false,
   "metadata": {
     "createdDate": "2018-07-19T00:00:00.000+0000",
     "createdByUserId": "28d1057c-d137-11e8-a8d5-f2801f1b9fd1"

--- a/mod-orders-storage/examples/acquisition_method_post.sample
+++ b/mod-orders-storage/examples/acquisition_method_post.sample
@@ -1,4 +1,5 @@
 {
   "value": "Purchase At Vendor System",
-  "source": "System"
+  "source": "System",
+  "deprecated": false
 }

--- a/mod-orders-storage/schemas/acquisition_method.json
+++ b/mod-orders-storage/schemas/acquisition_method.json
@@ -20,6 +20,11 @@
       ],
       "default": "User"
     },
+    "deprecated": {
+      "description": "Mark the acquisition method as deprecated to block new usage, but still allow it to be found in searches.",
+      "type": "boolean",
+      "default": false
+    },
     "metadata": {
       "type": "object",
       "$ref": "../../../raml-util/schemas/metadata.schema",


### PR DESCRIPTION
[MODORDSTOR-521](https://folio-org.atlassian.net/browse/MODORDSTOR-521)
[Deprecation of obsolete Acquisition Methods](https://folio-org.atlassian.net/wiki/spaces/FOLIJET/pages/2047967233/Deprecation+of+obsolete+Acquisition+Methods)

## Purpose
Acquisition administrators should be able to mark obsolete acquisition methods as deprecated, so that staff users can recognize such unused methods and they do not pollute their user interface.

## Approach
Add a deprecated boolean (default: false, optional) to the acquisition_method schema.

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Examples exist for all schemas
  - [x] Descriptions exist for all schema properties
  - [x] All schemas pass raml-cop linting
- Does this introduce breaking changes?
  - [x] Were there any schema changes?
  - [x] There are no breaking changes in this PR.
 
